### PR TITLE
refactor(#55): 컨텐츠 태그 리팩토링 및 컨텐츠 태그 조회 api 생성

### DIFF
--- a/src/main/java/com/example/RealMatch/business/domain/CampaignContentTag.java
+++ b/src/main/java/com/example/RealMatch/business/domain/CampaignContentTag.java
@@ -2,6 +2,7 @@ package com.example.RealMatch.business.domain;
 
 import com.example.RealMatch.campaign.domain.entity.Campaign;
 import com.example.RealMatch.global.common.BaseEntity;
+import com.example.RealMatch.tag.domain.entity.TagContent;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -35,7 +36,7 @@ public class CampaignContentTag extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "content_tag_id", nullable = false)
-    private ContentTag contentTag;
+    private TagContent tagContent;
 
     @Column(name = "custom_tag_value")
     private String customTagValue;
@@ -44,13 +45,13 @@ public class CampaignContentTag extends BaseEntity {
 
     private CampaignContentTag(
             Campaign campaign,
-            ContentTag contentTag,
+            TagContent tagContent,
             String customTagValue
     ) {
         this.campaign = campaign;
-        this.contentTag = contentTag;
+        this.tagContent = tagContent;
 
-        if (contentTag.getEngName().equals("ETC")) {
+        if (tagContent.getEngName().equals("ETC")) {
             if (customTagValue == null || customTagValue.isBlank()) {
                 throw new IllegalArgumentException("ETC 태그에는 입력값이 필요합니다.");
             }
@@ -63,17 +64,17 @@ public class CampaignContentTag extends BaseEntity {
     /* 일반 태그 */
     public static CampaignContentTag of(
             Campaign campaign,
-            ContentTag contentTag
+            TagContent tagContent
     ) {
-        return new CampaignContentTag(campaign, contentTag, null);
+        return new CampaignContentTag(campaign, tagContent, null);
     }
 
     /* 사용자 입력 태그 */
     public static CampaignContentTag ofCustom(
             Campaign campaign,
-            ContentTag contentTag,
+            TagContent tagContent,
             String customValue
     ) {
-        return new CampaignContentTag(campaign, contentTag, customValue);
+        return new CampaignContentTag(campaign, tagContent, customValue);
     }
 }

--- a/src/main/java/com/example/RealMatch/business/domain/CampaignProposalContentTag.java
+++ b/src/main/java/com/example/RealMatch/business/domain/CampaignProposalContentTag.java
@@ -1,6 +1,7 @@
 package com.example.RealMatch.business.domain;
 
 import com.example.RealMatch.global.common.BaseEntity;
+import com.example.RealMatch.tag.domain.entity.TagContent;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -34,7 +35,7 @@ public class CampaignProposalContentTag extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "content_tag_id", nullable = false)
-    private ContentTag contentTag;
+    private TagContent tagContent;
 
     @Column(name = "custom_tag_value")
     private String customTagValue;
@@ -43,13 +44,13 @@ public class CampaignProposalContentTag extends BaseEntity {
 
     private CampaignProposalContentTag(
             CampaignProposal campaignProposal,
-            ContentTag contentTag,
+            TagContent tagContent,
             String customTagValue
     ) {
         this.campaignProposal = campaignProposal;
-        this.contentTag = contentTag;
+        this.tagContent = tagContent;
 
-        if (contentTag.getEngName().equals("ETC")) {
+        if (tagContent.getEngName().equals("ETC")) {
             if (customTagValue == null || customTagValue.isBlank()) {
                 throw new IllegalArgumentException("ETC 태그에는 입력값이 필요합니다.");
             }
@@ -62,17 +63,17 @@ public class CampaignProposalContentTag extends BaseEntity {
     /* 일반 태그 */
     public static CampaignProposalContentTag of(
             CampaignProposal campaignProposal,
-            ContentTag contentTag
+            TagContent tagContent
     ) {
-        return new CampaignProposalContentTag(campaignProposal, contentTag, null);
+        return new CampaignProposalContentTag(campaignProposal, tagContent, null);
     }
 
     /* 사용자 입력 태그 */
     public static CampaignProposalContentTag ofCustom(
             CampaignProposal campaignProposal,
-            ContentTag contentTag,
+            TagContent tagContent,
             String customTagValue
     ) {
-        return new CampaignProposalContentTag(campaignProposal, contentTag, customTagValue);
+        return new CampaignProposalContentTag(campaignProposal, tagContent, customTagValue);
     }
 }

--- a/src/main/java/com/example/RealMatch/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/RealMatch/global/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
             "/api/test",
             "/api/login/success",
             "/ws/**",
-            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/swagger-ui.html"};
+            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/swagger-ui.html",
+            "/api/v1/tags/**"};
 
     private static final String[] REQUEST_AUTHENTICATED_ARRAY = {
             "/api/test-auth"

--- a/src/main/java/com/example/RealMatch/tag/application/service/TagContentService.java
+++ b/src/main/java/com/example/RealMatch/tag/application/service/TagContentService.java
@@ -1,0 +1,8 @@
+package com.example.RealMatch.tag.application.service;
+
+import com.example.RealMatch.tag.presentation.dto.response.ContentTagResponse;
+
+public interface TagContentService {
+
+    ContentTagResponse getContentTags();
+}

--- a/src/main/java/com/example/RealMatch/tag/application/service/TagContentServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/tag/application/service/TagContentServiceImpl.java
@@ -1,0 +1,47 @@
+package com.example.RealMatch.tag.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.RealMatch.tag.domain.enums.ContentTagType;
+import com.example.RealMatch.tag.domain.repository.TagContentRepository;
+import com.example.RealMatch.tag.presentation.dto.response.ContentTagResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagContentServiceImpl implements TagContentService {
+
+    private final TagContentRepository tagContentRepository;
+
+    @Override
+    public ContentTagResponse getContentTags() {
+
+        return new ContentTagResponse(
+                findBy(ContentTagType.FORMAT),
+                findBy(ContentTagType.CATEGORY),
+                findBy(ContentTagType.TONE),
+                findBy(ContentTagType.INVOLVEMENT),
+                findBy(ContentTagType.USAGE_RANGE)
+        );
+    }
+
+    private List<ContentTagResponse.TagItemResponse> findBy(
+            ContentTagType tagType
+    ) {
+        return tagContentRepository
+                .findByTagTypeOrderByDisplayOrderAsc(tagType)
+                .stream()
+                .map(tag -> new ContentTagResponse.TagItemResponse(
+                        tag.getId(),
+                        tag.getKorName(),
+                        tag.getDisplayOrder()
+                ))
+                .toList();
+    }
+}
+

--- a/src/main/java/com/example/RealMatch/tag/domain/entity/TagContent.java
+++ b/src/main/java/com/example/RealMatch/tag/domain/entity/TagContent.java
@@ -1,7 +1,7 @@
-package com.example.RealMatch.business.domain;
+package com.example.RealMatch.tag.domain.entity;
 
-import com.example.RealMatch.business.domain.enums.ContentTagType;
-import com.example.RealMatch.global.common.BaseEntity;
+import com.example.RealMatch.global.common.DeleteBaseEntity;
+import com.example.RealMatch.tag.domain.enums.ContentTagType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,12 +17,12 @@ import lombok.Getter;
 @Getter
 @Entity
 @Table(
-        name = "content_tag",
+        name = "tag_content",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"tag_type", "eng_name"})
         }
 )
-public class ContentTag extends BaseEntity {
+public class TagContent extends DeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,10 +41,10 @@ public class ContentTag extends BaseEntity {
     @Column(name = "display_order", nullable = false)
     private Integer displayOrder;
 
-    protected ContentTag() {
+    protected TagContent() {
     }
 
-    public ContentTag(
+    public TagContent(
             ContentTagType tagType,
             String engName,
             String korName,

--- a/src/main/java/com/example/RealMatch/tag/domain/enums/ContentTagType.java
+++ b/src/main/java/com/example/RealMatch/tag/domain/enums/ContentTagType.java
@@ -1,4 +1,4 @@
-package com.example.RealMatch.business.domain.enums;
+package com.example.RealMatch.tag.domain.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/RealMatch/tag/domain/repository/TagContentRepository.java
+++ b/src/main/java/com/example/RealMatch/tag/domain/repository/TagContentRepository.java
@@ -1,0 +1,14 @@
+package com.example.RealMatch.tag.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.RealMatch.tag.domain.entity.TagContent;
+import com.example.RealMatch.tag.domain.enums.ContentTagType;
+
+public interface TagContentRepository extends JpaRepository<TagContent, Long> {
+    List<TagContent> findByTagTypeOrderByDisplayOrderAsc(
+            ContentTagType tagType
+    );
+}

--- a/src/main/java/com/example/RealMatch/tag/presentation/controller/TagController.java
+++ b/src/main/java/com/example/RealMatch/tag/presentation/controller/TagController.java
@@ -1,0 +1,36 @@
+package com.example.RealMatch.tag.presentation.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.RealMatch.global.presentation.CustomResponse;
+import com.example.RealMatch.global.presentation.code.GeneralSuccessCode;
+import com.example.RealMatch.tag.application.service.TagContentService;
+import com.example.RealMatch.tag.presentation.dto.response.ContentTagResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/tags")
+@RequiredArgsConstructor
+@Tag(name = "Tag", description = "태그 조회 API")
+public class TagController {
+
+    private final TagContentService tagContentService;
+
+    @GetMapping("/content")
+    @Operation(
+            summary = "컨텐츠 태그 조회",
+            description = "컨텐츠 태그 목록을 조회합니다."
+    )
+    public CustomResponse<ContentTagResponse> getContentTags() {
+
+        return CustomResponse.onSuccess(
+                GeneralSuccessCode.FOUND,
+                tagContentService.getContentTags()
+        );
+    }
+}

--- a/src/main/java/com/example/RealMatch/tag/presentation/dto/response/ContentTagResponse.java
+++ b/src/main/java/com/example/RealMatch/tag/presentation/dto/response/ContentTagResponse.java
@@ -1,0 +1,22 @@
+package com.example.RealMatch.tag.presentation.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ContentTagResponse {
+    private List<TagItemResponse> formats;      // FORMAT
+    private List<TagItemResponse> categories;   // CATEGORY
+    private List<TagItemResponse> tones;        // TONE
+    private List<TagItemResponse> involvements; // INVOLVEMENT
+    private List<TagItemResponse> usageRanges;  // USAGE_RANGE
+
+    public record TagItemResponse(
+            Long id,
+            String name,        // kor_name
+            int displayOrder
+    ) {}
+}


### PR DESCRIPTION
[REFACTOR] 컨텐츠 태그 리팩토링

## Summary
business에 있던  content tag를 tag 폴더에서 책임 · 관리하도록 이동


## Changes
- [x] content_tag → tag_content로 이름 변경
- [x] tag_content를 business에서 tag로 파일 위치 변경
- [x] tag_content 조회하는 api 추가
- [x] securityConfig에서 permit_all 수정 (tag_content 조회 api 추가)


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [x] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
closed: #55 

## 참고 사항
노션에 insert 값 수정해두었습니다.