### PR TITLE
[FEAT] 회원정보 변경 API (#89)

### DIFF
--- a/src/main/java/com/example/RealMatch/user/application/service/UserService.java
+++ b/src/main/java/com/example/RealMatch/user/application/service/UserService.java
@@ -15,6 +15,7 @@ import com.example.RealMatch.user.domain.repository.AuthenticationMethodReposito
 import com.example.RealMatch.user.domain.repository.UserRepository;
 import com.example.RealMatch.user.infrastructure.ScrapMockDataProvider;
 import com.example.RealMatch.user.presentation.code.UserErrorCode;
+import com.example.RealMatch.user.presentation.dto.request.MyEditInfoRequestDto;
 import com.example.RealMatch.user.presentation.dto.response.MyEditInfoResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyPageResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyProfileCardResponseDto;
@@ -105,5 +106,26 @@ public class UserService {
 
         // DTO 변환 및 반환
         return MyEditInfoResponseDto.from(user, providers);
+    }
+
+    @Transactional
+    public void updateMyInfo(Long userId, MyEditInfoRequestDto request) {
+        // 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // 닉네임 중복 체크
+        if (userRepository.existsByEmail(request.nickname()) &&
+                !user.getNickname().equals(request.nickname())) {
+            throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        // 정보 수정
+        user.updateInfo(
+                request.nickname(),
+                request.address(),
+                request.detailAddress()
+        );
+
     }
 }

--- a/src/main/java/com/example/RealMatch/user/application/service/UserService.java
+++ b/src/main/java/com/example/RealMatch/user/application/service/UserService.java
@@ -115,7 +115,7 @@ public class UserService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         // 닉네임 중복 체크
-        if (userRepository.existsByEmail(request.nickname()) &&
+        if (userRepository.existsByNickname(request.nickname()) &&
                 !user.getNickname().equals(request.nickname())) {
             throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
         }

--- a/src/main/java/com/example/RealMatch/user/domain/entity/User.java
+++ b/src/main/java/com/example/RealMatch/user/domain/entity/User.java
@@ -15,18 +15,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "users",   uniqueConstraints = {
-        @UniqueConstraint(name = "uq_user_email_deleted", columnNames = {"email", "is_deleted"}),
-        @UniqueConstraint(name = "uq_user_nickname_deleted", columnNames = {"nickname", "is_deleted"})
-    }
-)
+@Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
@@ -94,12 +89,16 @@ public class User extends BaseEntity {
         this.lastLogin = LocalDateTime.now();
     }
 
-    public void updateProfile(String name, String nickname, String address, String detailAddress, String profileImageUrl) {
-        this.name = name;
+    public void updateProfileImage(String profileImageUrl) {
+        if (profileImageUrl != null && !profileImageUrl.isBlank()) {
+            this.profileImageUrl = profileImageUrl;
+        }
+    }
+
+    public void updateInfo(String nickname, String address, String detailAddress) {
         this.nickname = nickname;
         this.address = address;
         this.detailAddress = detailAddress;
-        this.profileImageUrl = profileImageUrl;
     }
 
     public void softDelete(Long deletedBy) {
@@ -115,4 +114,3 @@ public class User extends BaseEntity {
         this.role = role; // 여기서 Role.GUEST가 Role.CREATOR 등으로 바뀝니다.
     }
 }
-

--- a/src/main/java/com/example/RealMatch/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/RealMatch/user/domain/repository/UserRepository.java
@@ -17,5 +17,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.email = :email and u.isDeleted = false")
     Optional<User> findByEmail(@Param("email") String email);
 
-    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/RealMatch/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/RealMatch/user/domain/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 이메일로 조회 (Spring Security 인증 시 주로 사용)
     @Query("select u from User u where u.email = :email and u.isDeleted = false")
     Optional<User> findByEmail(@Param("email") String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/RealMatch/user/presentation/controller/UserController.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/controller/UserController.java
@@ -2,6 +2,8 @@ package com.example.RealMatch.user.presentation.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
 import com.example.RealMatch.user.application.service.UserService;
+import com.example.RealMatch.user.presentation.dto.request.MyEditInfoRequestDto;
 import com.example.RealMatch.user.presentation.dto.response.MyEditInfoResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyPageResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyProfileCardResponseDto;
@@ -16,6 +19,7 @@ import com.example.RealMatch.user.presentation.dto.response.MyScrapResponseDto;
 import com.example.RealMatch.user.presentation.swagger.UserSwagger;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "user", description = "유저 API")
@@ -58,5 +62,14 @@ public class UserController implements UserSwagger {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return CustomResponse.ok(userService.getMyEditInfo(userDetails.getUserId()));
+    }
+
+    @PostMapping("/me/edit")
+    public CustomResponse<Void> updateMyInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody MyEditInfoRequestDto request
+    ) {
+        userService.updateMyInfo(userDetails.getUserId(), request);
+        return CustomResponse.ok(null);
     }
 }

--- a/src/main/java/com/example/RealMatch/user/presentation/dto/request/MyEditInfoRequestDto.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/dto/request/MyEditInfoRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.RealMatch.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MyEditInfoRequestDto(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        String nickname,
+
+        @NotBlank(message = "주소는 필수입니다.")
+        String address,
+
+        @NotBlank(message = "상세 주소는 필수입니다.")
+        String detailAddress
+) {
+}

--- a/src/main/java/com/example/RealMatch/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/swagger/UserSwagger.java
@@ -1,9 +1,12 @@
 package com.example.RealMatch.user.presentation.swagger;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
+import com.example.RealMatch.user.presentation.dto.request.MyEditInfoRequestDto;
 import com.example.RealMatch.user.presentation.dto.response.MyEditInfoResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyPageResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyProfileCardResponseDto;
@@ -11,7 +14,10 @@ import com.example.RealMatch.user.presentation.dto.response.MyScrapResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "user", description = "유저 관련 API")
 public interface UserSwagger {
@@ -44,5 +50,16 @@ public interface UserSwagger {
     )
     CustomResponse<MyEditInfoResponseDto> getMyEditInfo(
             @Parameter(hidden = true) CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "회원정보 변경 API By 고경수", description = "사용자의 닉네임, 주소, 상세주소를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
+    })
+    CustomResponse<Void> updateMyInfo(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody MyEditInfoRequestDto request
     );
 }


### PR DESCRIPTION
## Summary
회원이 자신의 닉네임, 주소, 상세 주소를 수정할 수 있는 API를 구현했습니다.
입력 유효성 검증(@Valid)과 닉네임 중복 체크를 포함하며, 예외 발생 시 적절한 커스텀 메시지를 반환하도록 처리했습니다.

## Changes
MyEditInfoRequestDto 추가 및 입력 유효성 검증 (@NotBlank, @Size) 적용

UserService.updateMyInfo() 구현

닉네임 중복 체크

정보 수정

업데이트 실패 시 USER_UPDATE_BAD_REQUEST 예외 처리

User.updateInfo() 메서드 추가

UserController.updateMyInfo() 구현

@AuthenticationPrincipal로 로그인 유저 식별

서비스 호출 후 CustomResponse 반환


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
Closes #89

## 참고 사항
User 엔티티 수정 예정입니다