### PR TITLE
[FEAT] 소셜로그인 - 연동 계정 목록 조회 (#99) 

### DIFF
--- a/src/main/java/com/example/RealMatch/user/application/service/UserService.java
+++ b/src/main/java/com/example/RealMatch/user/application/service/UserService.java
@@ -131,8 +131,9 @@ public class UserService {
 
     public MyLoginResponseDto getSocialLoginInfo(Long userId) {
         // 유저 조회
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        if (!userRepository.existsById(userId)) {
+            throw new UserException(UserErrorCode.USER_NOT_FOUND);
+        }
 
         // 해당 유저의 모든 소셜 로그인 방법 조회
         List<AuthProvider> linkedProviders = authenticationMethodRepository.findByUserId(userId)

--- a/src/main/java/com/example/RealMatch/user/application/service/UserService.java
+++ b/src/main/java/com/example/RealMatch/user/application/service/UserService.java
@@ -141,11 +141,6 @@ public class UserService {
                 .map(AuthenticationMethod::getProvider)
                 .toList();
 
-        // 유저 로그인 정보를 불러오지 못했을 때
-        if (linkedProviders.isEmpty()) {
-            throw new UserException(UserErrorCode.SOCIAL_INFO_NOT_FOUND);
-        }
-
         // DTO 변환 및 반환
         return MyLoginResponseDto.from(linkedProviders);
     }

--- a/src/main/java/com/example/RealMatch/user/application/service/UserService.java
+++ b/src/main/java/com/example/RealMatch/user/application/service/UserService.java
@@ -17,6 +17,7 @@ import com.example.RealMatch.user.infrastructure.ScrapMockDataProvider;
 import com.example.RealMatch.user.presentation.code.UserErrorCode;
 import com.example.RealMatch.user.presentation.dto.request.MyEditInfoRequestDto;
 import com.example.RealMatch.user.presentation.dto.response.MyEditInfoResponseDto;
+import com.example.RealMatch.user.presentation.dto.response.MyLoginResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyPageResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyProfileCardResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyScrapResponseDto;
@@ -126,6 +127,25 @@ public class UserService {
                 request.address(),
                 request.detailAddress()
         );
+    }
 
+    public MyLoginResponseDto getSocialLoginInfo(Long userId) {
+        // 유저 조회
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // 해당 유저의 모든 소셜 로그인 방법 조회
+        List<AuthProvider> linkedProviders = authenticationMethodRepository.findByUserId(userId)
+                .stream()
+                .map(AuthenticationMethod::getProvider)
+                .toList();
+
+        // 유저 로그인 정보를 불러오지 못했을 때
+        if (linkedProviders.isEmpty()) {
+            throw new UserException(UserErrorCode.SOCIAL_INFO_NOT_FOUND);
+        }
+
+        // DTO 변환 및 반환
+        return MyLoginResponseDto.from(linkedProviders);
     }
 }

--- a/src/main/java/com/example/RealMatch/user/presentation/controller/UserController.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/controller/UserController.java
@@ -13,6 +13,7 @@ import com.example.RealMatch.global.presentation.CustomResponse;
 import com.example.RealMatch.user.application.service.UserService;
 import com.example.RealMatch.user.presentation.dto.request.MyEditInfoRequestDto;
 import com.example.RealMatch.user.presentation.dto.response.MyEditInfoResponseDto;
+import com.example.RealMatch.user.presentation.dto.response.MyLoginResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyPageResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyProfileCardResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyScrapResponseDto;
@@ -71,5 +72,13 @@ public class UserController implements UserSwagger {
     ) {
         userService.updateMyInfo(userDetails.getUserId(), request);
         return CustomResponse.ok(null);
+    }
+
+    @Override
+    @GetMapping("/me/social-login")
+    public CustomResponse<MyLoginResponseDto> getSocialLoginInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return CustomResponse.ok(userService.getSocialLoginInfo(userDetails.getUserId()));
     }
 }

--- a/src/main/java/com/example/RealMatch/user/presentation/dto/response/MyLoginResponseDto.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/dto/response/MyLoginResponseDto.java
@@ -25,10 +25,11 @@ public record MyLoginResponseDto(
     }
 
     public static MyLoginResponseDto from(List<AuthProvider> linkedProviders) {
+        java.util.Set<AuthProvider> linkedProvidersSet = new java.util.HashSet<>(linkedProviders);
         List<SocialLoginInfo> socialLoginInfos = Arrays.stream(AuthProvider.values())
                 .map(provider -> SocialLoginInfo.of(
                         provider,
-                        linkedProviders.contains(provider)
+                        linkedProvidersSet.contains(provider)
                 ))
                 .toList();
 

--- a/src/main/java/com/example/RealMatch/user/presentation/dto/response/MyLoginResponseDto.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/dto/response/MyLoginResponseDto.java
@@ -1,0 +1,39 @@
+package com.example.RealMatch.user.presentation.dto.response;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.example.RealMatch.user.domain.entity.enums.AuthProvider;
+
+import lombok.Builder;
+
+@Builder
+public record MyLoginResponseDto(
+        List<SocialLoginInfo> result
+) {
+    @Builder
+    public record SocialLoginInfo(
+            AuthProvider provider,
+            boolean isLinked
+    ) {
+        public static SocialLoginInfo of(AuthProvider provider, boolean isLinked) {
+            return SocialLoginInfo.builder()
+                    .provider(provider)
+                    .isLinked(isLinked)
+                    .build();
+        }
+    }
+
+    public static MyLoginResponseDto from(List<AuthProvider> linkedProviders) {
+        List<SocialLoginInfo> socialLoginInfos = Arrays.stream(AuthProvider.values())
+                .map(provider -> SocialLoginInfo.of(
+                        provider,
+                        linkedProviders.contains(provider)
+                ))
+                .toList();
+
+        return MyLoginResponseDto.builder()
+                .result(socialLoginInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/example/RealMatch/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/swagger/UserSwagger.java
@@ -8,6 +8,7 @@ import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
 import com.example.RealMatch.user.presentation.dto.request.MyEditInfoRequestDto;
 import com.example.RealMatch.user.presentation.dto.response.MyEditInfoResponseDto;
+import com.example.RealMatch.user.presentation.dto.response.MyLoginResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyPageResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyProfileCardResponseDto;
 import com.example.RealMatch.user.presentation.dto.response.MyScrapResponseDto;
@@ -61,5 +62,13 @@ public interface UserSwagger {
     CustomResponse<Void> updateMyInfo(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody MyEditInfoRequestDto request
+    );
+
+    @Operation(
+            summary = "소셜 로그인 연동 정보 조회 API By 고경수",
+            description = "현재 사용자의 소셜 로그인 연동 상태를 조회합니다. 카카오, 네이버, 구글 계정의 연동 여부를 확인할 수 있습니다."
+    )
+    CustomResponse<MyLoginResponseDto> getSocialLoginInfo(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }


### PR DESCRIPTION
## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->


## Changes
MyLoginResponseDto.java (신규 파일)

카카오, 네이버, 구글 등 모든 소셜 로그인 제공자의 연동 상태를 반환
AuthProvider enum의 모든 값을 순회하며 연동 여부 확인
UserController.java

GET /api/v1/users/me/social-login 엔드포인트 추가

UserSwagger.java
Swagger 문서에 새 API 명세 추가

UserService.java
getSocialLoginInfo() 메서드 추가
사용자의 연동된 소셜 계정 정보를 조회하여 DTO로 변환


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
Closes #99