### PR TITLE
[FEAT] 채팅 검색 기능 구현 (#125)

### DIFF
--- a/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomQueryService.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomQueryService.java
@@ -15,7 +15,8 @@ public interface ChatRoomQueryService {
             Long userId,
             ChatRoomFilterStatus filterStatus,
             RoomCursor roomCursor,
-            int size
+            int size,
+            String search
     );
 
     ChatRoomDetailResponse getChatRoomDetailWithOpponent(Long userId, Long roomId);

--- a/src/main/java/com/example/RealMatch/chat/domain/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/com/example/RealMatch/chat/domain/repository/ChatMessageRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.example.RealMatch.chat.domain.repository;
 
 import java.util.List;
+import java.util.Map;
 
 import com.example.RealMatch.chat.domain.entity.ChatMessage;
 
@@ -8,4 +9,6 @@ public interface ChatMessageRepositoryCustom {
     List<ChatMessage> findProposalMessagesByRoomId(Long roomId);
 
     List<ChatMessage> findMessagesByRoomId(Long roomId, Long cursorMessageId, int size);
+
+    Map<Long, ChatMessage> findLatestMatchingMessageByRoomIds(List<Long> roomIds, String search);
 }

--- a/src/main/java/com/example/RealMatch/chat/domain/repository/ChatMessageRepositoryCustomImpl.java
+++ b/src/main/java/com/example/RealMatch/chat/domain/repository/ChatMessageRepositoryCustomImpl.java
@@ -1,8 +1,11 @@
 package com.example.RealMatch.chat.domain.repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 import com.example.RealMatch.chat.domain.entity.ChatMessage;
 import com.example.RealMatch.chat.domain.entity.QChatMessage;
@@ -50,5 +53,26 @@ public class ChatMessageRepositoryCustomImpl implements ChatMessageRepositoryCus
                 .orderBy(MESSAGE.id.desc())
                 .limit(size + 1)
                 .fetch();
+    }
+
+    @Override
+    public Map<Long, ChatMessage> findLatestMatchingMessageByRoomIds(List<Long> roomIds, String search) {
+        if (roomIds == null || roomIds.isEmpty() || !StringUtils.hasText(search)) {
+            return Map.of();
+        }
+        String normalized = search.trim();
+        List<ChatMessage> list = queryFactory
+                .selectFrom(MESSAGE)
+                .where(
+                        MESSAGE.roomId.in(roomIds),
+                        MESSAGE.content.isNotNull(),
+                        MESSAGE.senderId.isNotNull(),
+                        MESSAGE.content.containsIgnoreCase(normalized)
+                )
+                .orderBy(MESSAGE.id.desc())
+                .fetch();
+        // 방별로 첫 번째(가장 최신) 메시지만 유지
+        return list.stream()
+                .collect(Collectors.toMap(ChatMessage::getRoomId, m -> m, (existing, replacement) -> existing));
     }
 }

--- a/src/main/java/com/example/RealMatch/chat/domain/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/example/RealMatch/chat/domain/repository/ChatRoomRepositoryCustom.java
@@ -12,7 +12,8 @@ public interface ChatRoomRepositoryCustom {
             Long userId,
             ChatRoomFilterStatus filterStatus,
             RoomCursorInfo cursorInfo,
-            int size
+            int size,
+            String search
     );
 
     long countTotalUnreadMessages(Long userId);

--- a/src/main/java/com/example/RealMatch/chat/presentation/rest/controller/ChatController.java
+++ b/src/main/java/com/example/RealMatch/chat/presentation/rest/controller/ChatController.java
@@ -52,10 +52,11 @@ public class ChatController implements ChatSwagger {
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(name = "status", required = false) ChatRoomFilterStatus filterStatus,
             @RequestParam(name = "cursor", required = false) RoomCursor roomCursor,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(name = "search", required = false) String search
     ) {
         Long userId = user.getUserId();
-        return CustomResponse.ok(chatRoomQueryService.getRoomList(userId, filterStatus, roomCursor, size));
+        return CustomResponse.ok(chatRoomQueryService.getRoomList(userId, filterStatus, roomCursor, size, search));
     }
 
     @GetMapping("/rooms/{roomId}")

--- a/src/main/java/com/example/RealMatch/chat/presentation/rest/swagger/ChatSwagger.java
+++ b/src/main/java/com/example/RealMatch/chat/presentation/rest/swagger/ChatSwagger.java
@@ -48,6 +48,7 @@ public interface ChatSwagger {
     @Operation(summary = "채팅방 목록 조회 API By 여채현",
             description = """
                     status 기준으로 채팅방 목록을 조회합니다.
+                    search가 있으면 상대방 이름(닉네임) 또는 메시지 내용으로 검색합니다 (부분 일치, 대소문자 무시).
                     정렬은 항상 lastMessageAt desc, roomId desc 기준입니다.
                     cursor는 lastMessageAt|roomId 포맷을 그대로 재사용하세요.
                     메시지가 없는 방은 목록에서 제외됩니다.
@@ -60,7 +61,8 @@ public interface ChatSwagger {
             @AuthenticationPrincipal CustomUserDetails user,
             @Parameter(description = "채팅방 필터 상태 (LATEST: 최신순, COLLABORATING: 협업중)") @RequestParam(name = "status", required = false) ChatRoomFilterStatus filterStatus,
             @Parameter(description = "페이지네이션 커서 (lastMessageAt|roomId 형식)") @RequestParam(name = "cursor", required = false) RoomCursor roomCursor,
-            @Parameter(description = "페이지 크기 (기본값: 20)") @RequestParam(defaultValue = "20") int size
+            @Parameter(description = "페이지 크기 (기본값: 20)") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "검색어 (상대방 이름 또는 메시지 내용, 미입력 시 전체 목록)") @RequestParam(name = "search", required = false) String search
     );
 
     @Operation(summary = "채팅방 헤더 조회 API By 여채현",


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
채팅방 목록 조회 API에 검색 기능을 추가했습니다. 사용자가 **상대방 이름(닉네임)** 또는 **메시지 내용**으로 채팅방을 검색할 수 있으며, 검색 시 목록에는 매칭된 메시지의 미리보기와 시간이 표시됩니다. 기존 필터(status), 페이지네이션(cursor, size)과 함께 동작합니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- **API**
  - `GET /api/v1/chat/rooms`에 optional 쿼리 파라미터 `search` 추가
  - 검색 시 상대방 이름 또는 메시지 내용 일치 방만 반환 (OR, 부분 일치, 대소문자 무시)
- **Repository**
  - `ChatRoomRepositoryCustom.findRoomsByUser(..., String search)` 시그니처 추가 및 검색 조건 적용 (상대방 닉네임 서브쿼리 + 메시지 content 서브쿼리)
  - `ChatMessageRepositoryCustom.findLatestMatchingMessageByRoomIds(roomIds, search)` 추가 — 검색 시 방별 매칭 메시지 1건 조회
- **Service / Assembler**
  - `ChatRoomQueryService.getRoomList(..., String search)` 시그니처 추가 및 검색 파라미터 전달
  - 검색 시 `ChatRoomCardAssembler`에서 매칭 메시지 기준으로 `lastMessagePreview` / `lastMessageAt` / `lastMessageType` 설정
- **Controller / Swagger**
  - `ChatController.getRoomList`에 `search` 파라미터 추가
  - `ChatSwagger`에 `search` 설명 및 검색 규칙 반영
- **문서**
  - `PRD/chat-rest-api.md` 채팅방 목록 조회 섹션에 `search` 파라미터 및 규칙 추가
- **테스트**
  - `chat-test.html`: 검색 입력/검색/초기화 버튼, 검색 시 API에 `search` 전달, 채팅방 목록 cursor 페이지네이션(더보기), 총 미읽음 뱃지 표시

## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #125 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 검색어가 없거나 공백만 있으면 기존과 동일하게 전체 목록을 반환합니다.
- 메시지 검색 시 시스템 메시지(senderId가 null인 메시지)는 제외됩니다.
- 상대방 이름 검색은 `User` 테이블과 조인하여 `nickname` 기준으로 수행하며, 채팅 도메인 Repository에서만 User 엔티티를 참조합니다.