### PR TITLE
fix(#150): 매칭 API 수정

### DIFF
--- a/src/main/java/com/example/RealMatch/match/presentation/controller/MatchController.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/controller/MatchController.java
@@ -2,14 +2,15 @@ package com.example.RealMatch.match.presentation.controller;
 
 import java.util.List;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
 import com.example.RealMatch.match.application.service.MatchService;
 import com.example.RealMatch.match.domain.entity.enums.CategoryType;
@@ -37,23 +38,25 @@ public class MatchController implements MatchSwagger {
     }
 
     @Override
-    @GetMapping("/brands/{userId}")
+    @GetMapping("/brands")
     public CustomResponse<MatchBrandResponseDto> getMatchingBrands(
-            @PathVariable String userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "MATCH_SCORE") SortType sortBy,
             @RequestParam(defaultValue = "ALL") CategoryType category,
             @RequestParam(required = false) List<String> tags) {
+        String userId = String.valueOf(userDetails.getUserId());
         MatchBrandResponseDto result = matchService.getMatchingBrands(userId, sortBy, category, tags);
         return CustomResponse.ok(result);
     }
 
     @Override
-    @GetMapping("/campaigns/{userId}")
+    @GetMapping("/campaigns")
     public CustomResponse<MatchCampaignResponseDto> getMatchingCampaigns(
-            @PathVariable String userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "MATCH_SCORE") SortType sortBy,
             @RequestParam(defaultValue = "ALL") CategoryType category,
             @RequestParam(required = false) List<String> tags) {
+        String userId = String.valueOf(userDetails.getUserId());
         MatchCampaignResponseDto result = matchService.getMatchingCampaigns(userId, sortBy, category, tags);
         return CustomResponse.ok(result);
     }

--- a/src/main/java/com/example/RealMatch/match/presentation/swagger/MatchSwagger.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/swagger/MatchSwagger.java
@@ -2,10 +2,11 @@ package com.example.RealMatch.match.presentation.swagger;
 
 import java.util.List;
 
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
 import com.example.RealMatch.match.domain.entity.enums.CategoryType;
 import com.example.RealMatch.match.domain.entity.enums.SortType;
@@ -94,7 +95,7 @@ public interface MatchSwagger {
 
     @Operation(summary = "매칭 브랜드 목록 조회",
             description = """
-                    사용자 ID를 기반으로 매칭률이 높은 브랜드 목록을 조회합니다.
+                    JWT 토큰의 사용자 ID를 기반으로 매칭률이 높은 브랜드 목록을 조회합니다.
                     정렬 옵션: MATCH_SCORE(매칭률 순), POPULARITY(인기순), NEWEST(신규순)
                     카테고리 필터: ALL(전체), FASHION(패션), BEAUTY(뷰티)
                     태그 필터: 뷰티/패션 관련 태그로 필터링
@@ -103,14 +104,14 @@ public interface MatchSwagger {
             @ApiResponse(responseCode = "200", description = "브랜드 목록 조회 성공")
     })
     CustomResponse<MatchBrandResponseDto> getMatchingBrands(
-            @Parameter(description = "사용자 ID") @PathVariable String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "정렬 기준 (MATCH_SCORE, POPULARITY, NEWEST)") @RequestParam(defaultValue = "MATCH_SCORE") SortType sortBy,
             @Parameter(description = "카테고리 필터 (ALL, FASHION, BEAUTY)") @RequestParam(defaultValue = "ALL") CategoryType category,
             @Parameter(description = "태그 필터 (예: 스킨케어, 미니멀)") @RequestParam(required = false) List<String> tags);
 
     @Operation(summary = "매칭 캠페인 목록 조회",
             description = """
-                    사용자 ID를 기반으로 매칭률이 높은 캠페인 목록을 조회합니다.
+                    JWT 토큰의 사용자 ID를 기반으로 매칭률이 높은 캠페인 목록을 조회합니다.
                     정렬 옵션: MATCH_SCORE(매칭률 순), POPULARITY(인기순), NEWEST(신규순)
                     카테고리 필터: ALL(전체), FASHION(패션), BEAUTY(뷰티)
                     태그 필터: 뷰티/패션 관련 태그로 필터링
@@ -119,7 +120,7 @@ public interface MatchSwagger {
             @ApiResponse(responseCode = "200", description = "캠페인 목록 조회 성공")
     })
     CustomResponse<MatchCampaignResponseDto> getMatchingCampaigns(
-            @Parameter(description = "사용자 ID") @PathVariable String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "정렬 기준 (MATCH_SCORE, POPULARITY, NEWEST)") @RequestParam(defaultValue = "MATCH_SCORE") SortType sortBy,
             @Parameter(description = "카테고리 필터 (ALL, FASHION, BEAUTY)") @RequestParam(defaultValue = "ALL") CategoryType category,
             @Parameter(description = "태그 필터 (예: 스킨케어, 미니멀)") @RequestParam(required = false) List<String> tags);


### PR DESCRIPTION
## Summary
매칭 API 수정. 기존 url에 userId를 넣는 방식에서 JWT 토큰에서 userId를 가져오는 방식으로 변경

## Changes
- MatchingController에서 매칭 API 조회 URL 변경

## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [X] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
#150 