### PR TITLE
feat(#149): 캠페인 다시 제안하기 기능 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignApplyQueryService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignApplyQueryService.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class CampaignApplyQueryService {
     private final CampaignApplyRepository campaignApplyRepository;
 
-    public CampaignApplyDetailResponse getMyApplyCampainDetails(Long campaignId, Long userId) {
+    public CampaignApplyDetailResponse getMyApplyCampaignDetails(Long campaignId, Long userId) {
         CampaignApply apply = campaignApplyRepository
                 .findByCampaignIdAndUserId(campaignId, userId)
                 .orElseThrow(() ->

--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
@@ -14,10 +14,12 @@ import com.example.RealMatch.brand.domain.repository.BrandRepository;
 import com.example.RealMatch.business.domain.entity.CampaignProposal;
 import com.example.RealMatch.business.domain.entity.CampaignProposalContentTag;
 import com.example.RealMatch.business.domain.repository.CampaignProposalRepository;
+import com.example.RealMatch.business.exception.BusinessErrorCode;
 import com.example.RealMatch.business.presentation.dto.request.CampaignProposalRequestDto;
 import com.example.RealMatch.campaign.domain.entity.Campaign;
 import com.example.RealMatch.campaign.domain.repository.CampaignRepository;
 import com.example.RealMatch.campaign.exception.CampaignErrorCode;
+import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.exception.CustomException;
 import com.example.RealMatch.tag.domain.entity.TagContent;
 import com.example.RealMatch.tag.domain.repository.TagContentRepository;
@@ -39,9 +41,11 @@ public class CampaignProposalService {
     private final BrandRepository brandRepository;
     private final CampaignRepository campaignRepository;
 
-    public void requestCampaign(Long userId, Role whoProposed, CampaignProposalRequestDto request) {
+    public void createCampaignProposal(CustomUserDetails userDetails, CampaignProposalRequestDto request) {
+        userRepository.findById(userDetails.getUserId())
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
-        User creator = userRepository.findById(userId)
+        User creator = userRepository.findById(request.getCreatorId())
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         Brand brand = brandRepository.findById(request.getBrandId())
@@ -53,11 +57,11 @@ public class CampaignProposalService {
                     .orElseThrow(() -> new CustomException(CampaignErrorCode.CAMPAIGN_NOT_FOUND));
         }
 
-
         CampaignProposal proposal = CampaignProposal.builder()
                 .creator(creator)
                 .brand(brand)
-                .whoProposed(whoProposed)
+                .whoProposed(Role.from(userDetails.getRole()))
+                .proposedUserId(userDetails.getUserId())
                 .campaign(campaign)
                 .title(request.getCampaignName())
                 .campaignDescription(request.getDescription())
@@ -67,16 +71,101 @@ public class CampaignProposalService {
                 .endDate(request.getEndDate())
                 .build();
 
-        saveTags(proposal, request.getFormats());
-        saveTags(proposal, request.getCategories());
-        saveTags(proposal, request.getTones());
-        saveTags(proposal, request.getInvolvements());
-        saveTags(proposal, request.getUsageRanges());
-
+        saveAllContentTags(request, proposal);
         campaignProposalRepository.save(proposal);
     }
 
-    private void saveTags(
+    @Transactional
+    public void modifyCampaignProposal(CustomUserDetails userDetails, UUID campaignProposalId, CampaignProposalRequestDto request) {
+        userRepository.findById(userDetails.getUserId())
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        CampaignProposal proposal = campaignProposalRepository.findById(campaignProposalId)
+                .orElseThrow(() -> new CustomException(
+                        BusinessErrorCode.CAMPAIGN_PROPOSAL_NOT_FOUND
+                ));
+
+        validateExistFields(request);
+        validateImmutableFields(request, proposal);
+        validateModifyAvailable(userDetails, proposal);
+
+        proposal.clearContentTags();
+        campaignProposalRepository.flush();
+
+        proposal.modify(
+                request.getCampaignName(),
+                request.getDescription(),
+                request.getRewardAmount(),
+                request.getProductId(),
+                request.getStartDate(),
+                request.getEndDate()
+        );
+        saveAllContentTags(request, proposal);
+    }
+
+    private static void validateModifyAvailable(CustomUserDetails userDetails, CampaignProposal proposal) {
+        if (!proposal.isModifiable()) {
+            throw new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_NOT_MODIFIABLE);
+        }
+
+        if (!proposal.getProposedUserId().equals(userDetails.getUserId())) {
+            throw new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_FORBIDDEN);
+        }
+
+        Role requesterRole = Role.from(userDetails.getRole());
+        if (proposal.getWhoProposed() != requesterRole) {
+            throw new CustomException(
+                    BusinessErrorCode.CAMPAIGN_PROPOSAL_ROLE_MISMATCH
+            );
+        }
+    }
+
+    private void validateExistFields(CampaignProposalRequestDto request) {
+        brandRepository.findById(request.getBrandId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 브랜드입니다."));
+
+        userRepository.findById(request.getCreatorId())
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        if (request.getCampaignId() != null) {
+            campaignRepository.findById(request.getCampaignId())
+                    .orElseThrow(() -> new CustomException(CampaignErrorCode.CAMPAIGN_NOT_FOUND));
+        }
+    }
+
+    private static void validateImmutableFields(CampaignProposalRequestDto request, CampaignProposal proposal) {
+        if (!proposal.getCreator().getId().equals(request.getCreatorId())) {
+            throw new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_CREATOR_IMMUTABLE);
+        }
+
+        if (!proposal.getBrand().getId().equals(request.getBrandId())) {
+            throw new CustomException(
+                    BusinessErrorCode.CAMPAIGN_PROPOSAL_BRAND_IMMUTABLE
+            );
+        }
+
+        if (proposal.getCampaign() != null) {
+            if (!proposal.getCampaign().getId().equals(request.getCampaignId())) {
+                throw new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_CAMPAIGN_IMMUTABLE);
+            }
+        } else {
+            if (request.getCampaignId() != null) {
+                throw new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_CAMPAIGN_IMMUTABLE);
+            }
+        }
+    }
+
+
+    private void saveAllContentTags(CampaignProposalRequestDto request, CampaignProposal proposal) {
+        saveContentTags(proposal, request.getFormats());
+        saveContentTags(proposal, request.getCategories());
+        saveContentTags(proposal, request.getTones());
+        saveContentTags(proposal, request.getInvolvements());
+        saveContentTags(proposal, request.getUsageRanges());
+    }
+
+
+    private void saveContentTags(
             CampaignProposal proposal,
             List<CampaignProposalRequestDto.CampaignContentTagRequest> tagRequests
     ) {
@@ -91,7 +180,6 @@ public class CampaignProposalService {
         if (tagContents.size() != tagIds.size()) {
             throw new IllegalArgumentException("존재하지 않는 태그가 포함되어 있습니다.");
         }
-
         // 3. Map<UUID, TagContent> 변환
         Map<UUID, TagContent> tagMap = tagContents.stream()
                 .collect(Collectors.toMap(
@@ -112,4 +200,9 @@ public class CampaignProposalService {
             );
         }
     }
+
+    private void validateNotChangedDate(UUID campaignProposalId, CampaignProposalRequestDto request) {
+
+    }
+
 }

--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
@@ -21,6 +21,7 @@ import com.example.RealMatch.campaign.domain.repository.CampaignRepository;
 import com.example.RealMatch.campaign.exception.CampaignErrorCode;
 import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.exception.CustomException;
+import com.example.RealMatch.global.presentation.code.GeneralErrorCode;
 import com.example.RealMatch.tag.domain.entity.TagContent;
 import com.example.RealMatch.tag.domain.repository.TagContentRepository;
 import com.example.RealMatch.user.domain.entity.User;
@@ -57,6 +58,8 @@ public class CampaignProposalService {
                     .orElseThrow(() -> new CustomException(CampaignErrorCode.CAMPAIGN_NOT_FOUND));
         }
 
+        validateDateRange(request);
+
         CampaignProposal proposal = CampaignProposal.builder()
                 .creator(creator)
                 .brand(brand)
@@ -88,6 +91,7 @@ public class CampaignProposalService {
         validateExistFields(request);
         validateImmutableFields(request, proposal);
         validateModifyAvailable(userDetails, proposal);
+        validateDateRange(request);
 
         proposal.clearContentTags();
         campaignProposalRepository.flush();
@@ -201,8 +205,14 @@ public class CampaignProposalService {
         }
     }
 
-    private void validateNotChangedDate(UUID campaignProposalId, CampaignProposalRequestDto request) {
-
+    private void validateDateRange(CampaignProposalRequestDto request) {
+        if (request.getStartDate() != null && request.getEndDate() != null) {
+            if (request.getEndDate().isBefore(request.getStartDate())) {
+                throw new CustomException(
+                        GeneralErrorCode.INVALID_DATA
+                );
+            }
+        }
     }
 
 }

--- a/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
+++ b/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
@@ -132,7 +132,7 @@ public class CampaignProposal extends BaseEntity {
             LocalDate startDate,
             LocalDate endDate
     ) {
-        if (this.campaign != null) {
+        if (this.campaign == null) {
             this.title = title;
         }
         this.campaignDescription = description;

--- a/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
+++ b/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
@@ -52,6 +52,9 @@ public class CampaignProposal extends BaseEntity {
     @Column(name = "who_proposed", nullable = false, length = 20)
     private Role whoProposed;
 
+    @Column(name = "proposed_user_id", nullable = false)
+    private Long proposedUserId;
+
     // 기존 캠페인 기반 제안이면 참조
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "campaign_id")
@@ -98,6 +101,7 @@ public class CampaignProposal extends BaseEntity {
             User creator,
             Brand brand,
             Role whoProposed,
+            Long proposedUserId,
             Campaign campaign,
             String title,
             String campaignDescription,
@@ -109,6 +113,7 @@ public class CampaignProposal extends BaseEntity {
         this.creator = creator;
         this.brand = brand;
         this.whoProposed = whoProposed;
+        this.proposedUserId = proposedUserId;
         this.campaign = campaign;
         this.title = title;
         this.campaignDescription = campaignDescription;
@@ -119,7 +124,34 @@ public class CampaignProposal extends BaseEntity {
         this.status = ProposalStatus.REVIEWING;
     }
 
+    public void modify(
+            String title,
+            String description,
+            Integer rewardAmount,
+            Long productId,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        if (this.campaign != null) {
+            this.title = title;
+        }
+        this.campaignDescription = description;
+        this.rewardAmount = rewardAmount;
+        this.productId = productId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+
     /* ===== 도메인 메서드 ===== */
+
+    public boolean isModifiable() {
+        return this.status == ProposalStatus.REVIEWING;
+    }
+
+    public void clearContentTags() {
+        this.tags.clear();
+    }
 
     public boolean isNewCampaignProposal() {
         return campaign == null;
@@ -137,7 +169,6 @@ public class CampaignProposal extends BaseEntity {
     public void addTag(CampaignProposalContentTag tag) {
         this.tags.add(tag);
     }
-
     /**
      * MATCHED 시 Campaign 생성용 변환 (추가 확인 필요, 태그 관리 필요)
      */

--- a/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
+++ b/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
@@ -19,9 +19,11 @@ public enum BusinessErrorCode implements BaseErrorCode {
     CAMPAIGN_PROPOSAL_BRAND_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_2", "캠페인 제안의 브랜드는 변경할 수 없습니다."),
     CAMPAIGN_PROPOSAL_CREATOR_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CREATOR_PROPOSAL_400_3", "캠페인 제안에 크리에이터는 변경할 수 없습니다."),
     CAMPAIGN_PROPOSAL_CAMPAIGN_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_4", "캠페인 제안에 연결된 캠페인은 변경할 수 없습니다."),
+    CAMPAIGN_PROPOSAL_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_5", "캠페인 제작 시작 날짜가 마감 날짜보나 늦을 수 없습니다."),
     CAMPAIGN_PROPOSAL_FORBIDDEN(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_1", "해당 캠페인 제안을 수정할 권한이 없습니다."),
     CAMPAIGN_PROPOSAL_ROLE_MISMATCH(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_2", "캠페인 제안 주체와 요청자의 역할이 일치하지 않습니다."),
     CAMPAIGN_PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_CAMPAIGN_PROPOSAL_404_2", "캠페인 제안 내역이 없습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
+++ b/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
@@ -12,10 +12,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum BusinessErrorCode implements BaseErrorCode {
 
-    // ===== 조회 =====
     CAMPAIGN_APPLY_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_APPLY_400_1", "이미 지원한 캠페인입니다."),
     CAMPAIGN_APPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_CAMPAIGN_APPLY_404_1", "캠페인 지원 내역이 없습니다."),
 
+    CAMPAIGN_PROPOSAL_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_1", "현재 상태에서는 캠페인 제안을 수정할 수 없습니다."),
+    CAMPAIGN_PROPOSAL_BRAND_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_2", "캠페인 제안의 브랜드는 변경할 수 없습니다."),
+    CAMPAIGN_PROPOSAL_CREATOR_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CREATOR_PROPOSAL_400_3", "캠페인 제안에 크리에이터는 변경할 수 없습니다."),
+    CAMPAIGN_PROPOSAL_CAMPAIGN_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_4", "캠페인 제안에 연결된 캠페인은 변경할 수 없습니다."),
+    CAMPAIGN_PROPOSAL_FORBIDDEN(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_1", "해당 캠페인 제안을 수정할 권한이 없습니다."),
+    CAMPAIGN_PROPOSAL_ROLE_MISMATCH(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_2", "캠페인 제안 주체와 요청자의 역할이 일치하지 않습니다."),
     CAMPAIGN_PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_CAMPAIGN_PROPOSAL_404_2", "캠페인 제안 내역이 없습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/example/RealMatch/business/presentation/controller/CampaignApplyController.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/controller/CampaignApplyController.java
@@ -18,6 +18,7 @@ import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -39,6 +40,7 @@ public class CampaignApplyController {
     )
     @PostMapping("/{campaignId}/apply")
     public CustomResponse<String> applyCampaign(
+            @Parameter(description = "캠페인 ID", example = "1")
             @PathVariable Long campaignId,
             @AuthenticationPrincipal CustomUserDetails principal,
             @Validated @RequestBody CampaignApplyRequest request
@@ -65,12 +67,13 @@ public class CampaignApplyController {
                     """
     )
     @GetMapping("/{campaignId}/apply/me")
-    public ResponseEntity<CampaignApplyDetailResponse> getMyApplyCampainDetails(
+    public ResponseEntity<CampaignApplyDetailResponse> getMyApplyCampaignDetails(
+            @Parameter(description = "캠페인 ID", example = "1")
             @PathVariable Long campaignId,
             @AuthenticationPrincipal CustomUserDetails principal
     ) {
         CampaignApplyDetailResponse response =
-                campaignApplyQueryService.getMyApplyCampainDetails(campaignId, principal.getUserId());
+                campaignApplyQueryService.getMyApplyCampaignDetails(campaignId, principal.getUserId());
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/RealMatch/business/presentation/controller/CampaignProposalController.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/controller/CampaignProposalController.java
@@ -17,9 +17,9 @@ import com.example.RealMatch.business.presentation.dto.request.CampaignProposalR
 import com.example.RealMatch.business.presentation.dto.response.CampaignProposalDetailResponse;
 import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
-import com.example.RealMatch.user.domain.entity.enums.Role;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,19 +40,41 @@ public class CampaignProposalController implements CampaignProposalSwagger {
                     크리에이터가 브랜드에 캠페인을 제안합니다.
                     
                     신규 캠페인인 경우 campaignId null을 보내주세요.
-                    기존 캠페인인 경우 campaignId을 보내주세요.
+                    기존 캠페인인 경우 campaignId을 보내주세요 + campaignName도 기존 캠페인의 campaignName 값을 넣어주세요.
                     
                     기타인 경우 customValue를 포함해서 보내주세요.
                     
                     태그 ID는 api/v1/tags/content에서 확인할 수 있습니다.
                     """
     )
-    public CustomResponse<String> requestCampaignProposal(
+    public CustomResponse<String> createCampaignProposal(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid CampaignProposalRequestDto request
     ) {
-        campaignProposalService.requestCampaign(userDetails.getUserId(), Role.from(userDetails.getRole()), request);
+        campaignProposalService.createCampaignProposal(userDetails,  request);
         return CustomResponse.ok("캠페인 제안에 성공했습니다.");
+    }
+
+    @Override
+    @PostMapping("/{campaignProposalID}/re-request")
+    @Operation(
+            summary = "캠페인 제안 수정(다시 제안하기) API by 박지영",
+            description = """
+                    내가 제안했던 것을 다시 제안하는 API 입니다.    
+                    /api/v1/campaigns/proposal/request에서 생성했던 제안을 수정해서 다시 제안할 때, 해당 API를 사용해주세요.   
+                    
+                    campaignProposalId는 /api/v1/campaigns/collaborations/me에서 확인해주세요.     
+                    (masterJWT로 조회 불가능 API, 크리에이터/브랜드 계정으로 로그인 필요)
+                    """
+    )
+    public CustomResponse<String> modifyCampaignProposal(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "캠페인 Proposal ID", example = "43bf11cd-b075-4187-b43b-07ee5cd54d41")
+            @PathVariable UUID campaignProposalID,
+            @RequestBody @Valid CampaignProposalRequestDto request
+    ) {
+        campaignProposalService.modifyCampaignProposal(userDetails, campaignProposalID, request);
+        return CustomResponse.ok("캠페인 제안을 수정했습니다.");
     }
 
     @GetMapping("/{campaignProposalId}")
@@ -60,6 +82,9 @@ public class CampaignProposalController implements CampaignProposalSwagger {
             summary = "켐페인 제안 상세 조회 API by 박지영",
             description = """
                     한 건의 캠페인 제안 상세 정보를 조회합니다.
+                    
+                    campaignProposalId는 /api/v1/campaigns/collaborations/me에서 확인해주세요.    
+                    (masterJWT로 조회 불가능 API, 크리에이터/브랜드 계정으로 로그인 필요)
                     
                     <태그>   
                     formats : 형식    
@@ -71,6 +96,7 @@ public class CampaignProposalController implements CampaignProposalSwagger {
     )
     public CustomResponse<CampaignProposalDetailResponse> getProposalDetail(
             @AuthenticationPrincipal CustomUserDetails principal,
+            @Parameter(description = "캠페인 Proposal ID", example = "43bf11cd-b075-4187-b43b-07ee5cd54d41")
             @PathVariable UUID campaignProposalId
     ) {
         CampaignProposalDetailResponse response =

--- a/src/main/java/com/example/RealMatch/business/presentation/docs/CampaignProposalSwagger.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/docs/CampaignProposalSwagger.java
@@ -1,12 +1,16 @@
 package com.example.RealMatch.business.presentation.docs;
 
+import java.util.UUID;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import com.example.RealMatch.business.presentation.dto.request.CampaignProposalRequestDto;
 import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -64,8 +68,65 @@ public interface CampaignProposalSwagger {
                     )
             )
     )
-    CustomResponse<String> requestCampaignProposal(
+    CustomResponse<String> createCampaignProposal(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid CampaignProposalRequestDto request
     );
+
+    @Operation(
+            summary = "캠페인 제안 수정(다시 제안하기) API by 박지영",
+            description = """
+                    내가 제안했던 것을 다시 제안하는 API 입니다.    
+                    /api/v1/campaigns/proposal/request에서 생성했던 제안을 수정해서 다시 제안할 때, 해당 API를 사용해주세요.   
+                    
+                    campaignProposalId는 /api/v1/campaigns/collaborations/me에서 확인해주세요.     
+                    (masterJWT로 조회 불가능 API, 크리에이터/브랜드 계정으로 로그인 필요)
+                    """
+    )
+    @RequestBody(
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(
+                            name = "CampaignProposalRequestExample",
+                            summary = "캠페인 수정 요청 예시",
+                            value = """
+                                    {
+                                      "brandId": 1,
+                                      "creatorId": 1,
+                                      "campaignId": null,
+                                      "campaignName": "비플레인 선크림 리뷰 캠페인",
+                                      "description": "비플레인 선크림을 체험하고 솔직한 리뷰 콘텐츠를 제작해주세요.",
+                                                                  "formats": [
+                                                                    { "id": "32000000-0000-0000-0000-000000000000" }
+                                                                  ],
+                                                                  "categories": [
+                                                                    { "id": "31310000-0000-0000-0000-000000000000", "customValue": "성분 분석 리뷰" },
+                                                                    { "id": "38000000-0000-0000-0000-000000000000"}
+                                                                  ],
+                                                                  "tones": [
+                                                                    { "id": "31360000-0000-0000-0000-000000000000" }
+                                                                  ],
+                                                                  "involvements": [
+                                                                    { "id": "32320000-0000-0000-0000-000000000000" }
+                                                                  ],
+                                                                  "usageRanges": [
+                                                                    { "id": "32350000-0000-0000-0000-000000000000" }
+                                                                  ],
+                                      "rewardAmount": 100000,
+                                      "productId": 5,
+                                      "startDate": "2025-03-29",
+                                      "endDate": "2025-04-01"
+                                    }
+                                    """
+                    )
+            )
+    )
+    CustomResponse<String> modifyCampaignProposal(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "캠페인 Proposal ID", example = "43bf11cd-b075-4187-b43b-07ee5cd54d41")
+            @PathVariable UUID campaignProposalID,
+            @org.springframework.web.bind.annotation.RequestBody @Valid CampaignProposalRequestDto request
+    );
+
 }

--- a/src/main/java/com/example/RealMatch/global/presentation/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/RealMatch/global/presentation/advice/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.example.RealMatch.global.exception.CustomException;
 import com.example.RealMatch.global.presentation.CustomResponse;
@@ -92,5 +93,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(CustomResponse.onFailure(errorCode, null));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<CustomResponse<?>> handleTypeMismatch(
+            MethodArgumentTypeMismatchException e
+    ) {
+        return ResponseEntity
+                .badRequest()
+                .body(CustomResponse.onFailure(
+                        GeneralErrorCode.INVALID_DATA,
+                        "날짜 형식은 yyyy-MM-dd 형식이어야 합니다."
+                ));
     }
 }


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->


## Changes
- [x] 캠페인 다시 제안하기 기능 추가
- [x] 캠페인 제안 기능에서 제안한 proposed_user_id 값 넣는 로직 추가
- [x] swagger docs 설명 추가
- [x] CampaignProposal 엔티티에서 proposed_user_id 필드 추가 (서버에 reason, user_id, proposal_reason 삭제 )
<img width="373" height="224" alt="image" src="https://github.com/user-attachments/assets/d6969e58-d028-4300-9624-67ad5f0dfd57" />





## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [x] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [x] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
#149 

## 참고 사항
CampaignProposal 엔티티가 수정되었습니다.