### PR TITLE
 [REFACTOR] Attachment URL 생성 로직을 키 기반으로 분리 (#164)

### DIFF
--- a/src/main/java/com/example/RealMatch/attachment/application/service/AttachmentUrlService.java
+++ b/src/main/java/com/example/RealMatch/attachment/application/service/AttachmentUrlService.java
@@ -38,14 +38,21 @@ public class AttachmentUrlService {
             return null;
         }
         try {
-            return s3FileUploadService.generatePresignedUrl(
-                    storageKey,
-                    s3Properties.getPresignedUrlExpirationSeconds()
-            );
+            return getAccessUrl(storageKey);
         } catch (Exception e) {
             LOG.warn("Presigned URL 생성 실패. attachmentId={}, s3Key={}",
                     attachment.getId(), storageKey, e);
             return null;
         }
+    }
+
+    public String getAccessUrl(String storageKey) {
+        if (storageKey == null || storageKey.isBlank()) {
+            return null;
+        }
+        return s3FileUploadService.generatePresignedUrl(
+                storageKey,
+                s3Properties.getPresignedUrlExpirationSeconds()
+        );
     }
 }

--- a/src/main/java/com/example/RealMatch/attachment/infrastructure/storage/NoOpS3FileUploadService.java
+++ b/src/main/java/com/example/RealMatch/attachment/infrastructure/storage/NoOpS3FileUploadService.java
@@ -2,7 +2,7 @@ package com.example.RealMatch.attachment.infrastructure.storage;
 
 import java.io.InputStream;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +12,7 @@ import com.example.RealMatch.global.exception.CustomException;
 
 @Service
 @Profile("!prod")
-@ConditionalOnMissingBean(S3FileUploadService.class)
+@Conditional(S3CredentialsMissingCondition.class)
 public class NoOpS3FileUploadService implements S3FileUploadService {
 
     @Override

--- a/src/main/java/com/example/RealMatch/attachment/infrastructure/storage/S3CredentialsMissingCondition.java
+++ b/src/main/java/com/example/RealMatch/attachment/infrastructure/storage/S3CredentialsMissingCondition.java
@@ -1,0 +1,23 @@
+package com.example.RealMatch.attachment.infrastructure.storage;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+/**
+ * S3 자격증명이 설정되지 않았을 때 true
+ * NoOpS3FileUploadService 등록용
+ */
+public class S3CredentialsMissingCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        String accessKeyId = context.getEnvironment()
+                .getProperty("app.s3.access-key-id");
+        String secretAccessKey = context.getEnvironment()
+                .getProperty("app.s3.secret-access-key");
+
+        return !StringUtils.hasText(accessKeyId) || !StringUtils.hasText(secretAccessKey);
+    }
+}


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
Attachment URL 생성 로직을 storage key 기반으로 분리했습니다.


## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- `AttachmentUrlService`에 `getAccessUrl(String storageKey)` 오버로드 추가
- 기존 `getAccessUrl(Attachment)`가 키 기반 메소드로 위임


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #164 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->