### PR TITLE
fix(#169): 매칭 조회 API 수정

### DIFF
--- a/data/generators/match_generator.py
+++ b/data/generators/match_generator.py
@@ -75,6 +75,8 @@ class MatchGenerator(BaseGenerator):
                     data['brand_id'] = brand_id
                 if 'matching_ratio' in columns:
                     data['matching_ratio'] = self.fake.random_int(50, 100)
+                if 'is_deprecated' in columns:
+                    data['is_deprecated'] = False
                 if 'is_deleted' in columns:
                     data['is_deleted'] = False
                 if 'created_at' in columns:
@@ -130,6 +132,8 @@ class MatchGenerator(BaseGenerator):
                     data['campaign_id'] = campaign_id
                 if 'matching_ratio' in columns:
                     data['matching_ratio'] = self.fake.random_int(50, 100)
+                if 'is_deprecated' in columns:
+                    data['is_deprecated'] = False
                 if 'is_deleted' in columns:
                     data['is_deleted'] = False
                 if 'created_at' in columns:

--- a/src/main/java/com/example/RealMatch/campaign/domain/repository/CampaignRepository.java
+++ b/src/main/java/com/example/RealMatch/campaign/domain/repository/CampaignRepository.java
@@ -3,6 +3,7 @@ package com.example.RealMatch.campaign.domain.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -65,4 +66,6 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long> {
     """)
     List<Campaign> findRecruitingCampaignsByBrandId(Long brandId);
 
+    @Query("SELECT DISTINCT c.brand.id FROM Campaign c WHERE c.recruitEndDate > :now")
+    Set<Long> findRecruitingBrandIds(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/example/RealMatch/match/domain/entity/MatchBrandHistory.java
+++ b/src/main/java/com/example/RealMatch/match/domain/entity/MatchBrandHistory.java
@@ -39,14 +39,22 @@ public class MatchBrandHistory extends DeleteBaseEntity {
     @Column(name = "matching_ratio")
     private Long matchingRatio;
 
+    @Column(name = "is_deprecated", nullable = false)
+    private Boolean isDeprecated = false;
+
     @Builder
     public MatchBrandHistory(User user, Brand brand, Long matchingRatio) {
         this.user = user;
         this.brand = brand;
         this.matchingRatio = matchingRatio;
+        this.isDeprecated = false;
     }
 
     public void updateMatchingRatio(Long matchingRatio) {
         this.matchingRatio = matchingRatio;
+    }
+
+    public void deprecate() {
+        this.isDeprecated = true;
     }
 }

--- a/src/main/java/com/example/RealMatch/match/domain/entity/MatchCampaignHistory.java
+++ b/src/main/java/com/example/RealMatch/match/domain/entity/MatchCampaignHistory.java
@@ -39,14 +39,22 @@ public class MatchCampaignHistory extends DeleteBaseEntity {
     @Column(name = "matching_ratio")
     private Long matchingRatio;
 
+    @Column(name = "is_deprecated", nullable = false)
+    private Boolean isDeprecated = false;
+
     @Builder
     public MatchCampaignHistory(User user, Campaign campaign, Long matchingRatio) {
         this.user = user;
         this.campaign = campaign;
         this.matchingRatio = matchingRatio;
+        this.isDeprecated = false;
     }
 
     public void updateMatchingRatio(Long matchingRatio) {
         this.matchingRatio = matchingRatio;
+    }
+
+    public void deprecate() {
+        this.isDeprecated = true;
     }
 }

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
@@ -18,4 +18,8 @@ public interface MatchBrandHistoryRepository extends JpaRepository<MatchBrandHis
     Optional<MatchBrandHistory> findByUserIdAndBrandId(Long userId, Long brandId);
 
     List<MatchBrandHistory> findByUserIdOrderByMatchingRatioDesc(Long userId);
+
+    List<MatchBrandHistory> findByUserIdAndIsDeprecatedFalse(Long userId);
+
+    List<MatchBrandHistory> findByUserIdAndIsDeprecatedFalseOrderByMatchingRatioDesc(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.RealMatch.match.domain.entity.MatchBrandHistory;
 
@@ -22,4 +25,8 @@ public interface MatchBrandHistoryRepository extends JpaRepository<MatchBrandHis
     List<MatchBrandHistory> findByUserIdAndIsDeprecatedFalse(Long userId);
 
     List<MatchBrandHistory> findByUserIdAndIsDeprecatedFalseOrderByMatchingRatioDesc(Long userId);
+
+    @Modifying
+    @Query("UPDATE MatchBrandHistory h SET h.isDeprecated = true WHERE h.user.id = :userId AND h.isDeprecated = false")
+    int bulkDeprecateByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchCampaignHistoryRepository.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchCampaignHistoryRepository.java
@@ -20,5 +20,9 @@ public interface MatchCampaignHistoryRepository extends JpaRepository<MatchCampa
     Optional<MatchCampaignHistory> findByUserIdAndCampaignId(Long userId, Long campaignId);
 
     List<MatchCampaignHistory> findByUserIdOrderByMatchingRatioDesc(Long userId);
+
+    List<MatchCampaignHistory> findByUserIdAndIsDeprecatedFalse(Long userId);
+
+    List<MatchCampaignHistory> findByUserIdAndIsDeprecatedFalseOrderByMatchingRatioDesc(Long userId);
 }
 

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchCampaignHistoryRepository.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchCampaignHistoryRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.RealMatch.match.domain.entity.MatchCampaignHistory;
 
@@ -24,5 +27,9 @@ public interface MatchCampaignHistoryRepository extends JpaRepository<MatchCampa
     List<MatchCampaignHistory> findByUserIdAndIsDeprecatedFalse(Long userId);
 
     List<MatchCampaignHistory> findByUserIdAndIsDeprecatedFalseOrderByMatchingRatioDesc(Long userId);
+
+    @Modifying
+    @Query("UPDATE MatchCampaignHistory h SET h.isDeprecated = true WHERE h.user.id = :userId AND h.isDeprecated = false")
+    int bulkDeprecateByUserId(@Param("userId") Long userId);
 }
 

--- a/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchBrandResponseDto.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchBrandResponseDto.java
@@ -23,6 +23,7 @@ public class MatchBrandResponseDto {
     public static class BrandDto {
         private Long brandId;
         private String brandName;
+        private String brandLogoUrl;
         private Integer brandMatchingRatio;
         private Boolean brandIsLiked;
         private Boolean brandIsRecruiting;

--- a/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchCampaignResponseDto.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchCampaignResponseDto.java
@@ -23,6 +23,7 @@ public class MatchCampaignResponseDto {
     public static class CampaignDto {
         private Long brandId;
         private String brandName;
+        private String brandLogoUrl;
         private Integer brandMatchingRatio;
         private Boolean brandIsLiked;
         private Boolean brandIsRecruiting;


### PR DESCRIPTION
## Summary
기존 Redis에서 매칭 결과를 조회하는 방식에서 DB에서 조회하는 방식으로 변경

## Changes
- DB 조회 방식 변경
- ResponseDto에 url 반환 반영
- N+1 문제를 해결하기 위해 벌크 업데이트와 배치 처리로 개선
- getRecruitingBrandIds 메서드 호출해서 N+1 쿼리 문제 개선

## Type of Change
- [X] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
#169 