### PR TITLE
[FEAT] 닉네임 중복/글자수/특수기호 예외 로직 구현 (#193)

### DIFF
--- a/src/main/java/com/example/RealMatch/oauth/code/OAuthErrorCode.java
+++ b/src/main/java/com/example/RealMatch/oauth/code/OAuthErrorCode.java
@@ -41,6 +41,30 @@ public enum OAuthErrorCode implements BaseErrorCode {
             "필수 약관에 동의하지 않았습니다."
     ),
 
+    INVALID_NICKNAME(
+            HttpStatus.BAD_REQUEST,
+            "AUTH400_6",
+            "닉네임은 필수 입력값입니다."
+    ),
+
+    INVALID_NICKNAME_LENGTH(
+            HttpStatus.BAD_REQUEST,
+            "AUTH400_7",
+            "닉네임은 2~10자 사이여야 합니다."
+    ),
+
+    INVALID_NICKNAME_FORMAT(
+            HttpStatus.BAD_REQUEST,
+            "AUTH400_8",
+            "닉네임은 한글, 영문, 숫자만 사용 가능합니다."
+    ),
+
+    FORBIDDEN_NICKNAME(
+            HttpStatus.BAD_REQUEST,
+            "AUTH400_9",
+            "사용할 수 없는 닉네임입니다."
+    ),
+
     INVALID_TOKEN(
             HttpStatus.UNAUTHORIZED,
             "AUTH401_1",
@@ -75,6 +99,12 @@ public enum OAuthErrorCode implements BaseErrorCode {
             HttpStatus.NOT_FOUND,
             "AUTH404_4",
             "콘텐츠 카테고리를 찾을 수 없습니다."
+    ),
+
+    DUPLICATE_NICKNAME(
+            HttpStatus.CONFLICT,
+            "AUTH409_1",
+            "이미 사용 중인 닉네임입니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/com/example/RealMatch/oauth/dto/request/SignupCompleteRequest.java
+++ b/src/main/java/com/example/RealMatch/oauth/dto/request/SignupCompleteRequest.java
@@ -38,10 +38,10 @@ public record SignupCompleteRequest(
             """)
         List<TermAgreementDto> terms,
 
-        @Schema(description = "가입 목적 ID 리스트", example = "[1, 2]")
+        @Schema(description = "가입 목적 ID 리스트", example = "[1, 2, 3, 6]")
         List<Long> signupPurposeIds,
 
-        @Schema(description = "관심 콘텐츠 카테고리 ID 리스트", example = "[1, 3, 5]")
+        @Schema(description = "관심 콘텐츠 카테고리 ID 리스트", example = "[1, 2]")
         List<Long> contentCategoryIds
 ) {
     public record TermAgreementDto(

--- a/src/main/java/com/example/RealMatch/oauth/service/AuthService.java
+++ b/src/main/java/com/example/RealMatch/oauth/service/AuthService.java
@@ -52,6 +52,9 @@ public class AuthService {
             throw new CustomException(OAuthErrorCode.ALREADY_SIGNED_UP);
         }
 
+        // ⭐ 닉네임 중복 체크 추가
+        validateNickname(request.nickname());
+
         // 유저 정보 업데이트
         user.completeSignup(
                 request.nickname(),
@@ -108,6 +111,28 @@ public class AuthService {
             return header.substring(7);
         }
         return header;
+    }
+
+    private void validateNickname(String nickname) {
+        // 1. null/빈 문자열 체크
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new CustomException(OAuthErrorCode.INVALID_NICKNAME);
+        }
+
+        // 2. 길이 체크 (2~10자)
+        if (nickname.length() < 2 || nickname.length() > 10) {
+            throw new CustomException(OAuthErrorCode.INVALID_NICKNAME_LENGTH);
+        }
+
+        // 3. 형식 체크 (한글, 영문, 숫자만)
+        if (!nickname.matches("^[가-힣a-zA-Z0-9]+$")) {
+            throw new CustomException(OAuthErrorCode.INVALID_NICKNAME_FORMAT);
+        }
+
+        // 4. 중복 체크
+        if (userRepository.existsByNickname(nickname)) {
+            throw new CustomException(OAuthErrorCode.DUPLICATE_NICKNAME);
+        }
     }
 
     private void saveTermAgreements(User user, List<SignupCompleteRequest.TermAgreementDto> terms) {

--- a/src/main/java/com/example/RealMatch/user/application/service/UserService.java
+++ b/src/main/java/com/example/RealMatch/user/application/service/UserService.java
@@ -121,6 +121,16 @@ public class UserService {
             throw new CustomException(UserErrorCode.DUPLICATE_NICKNAME);
         }
 
+        // 닉네임 형식 체크 (한글, 영문, 숫자만)
+        if (!request.nickname().matches("^[가-힣a-zA-Z0-9]+$")) {
+            throw new CustomException(UserErrorCode.INVALID_NICKNAME_FORMAT);
+        }
+
+        // 닉네임 길이 체크 (2~10자)
+        if (request.nickname().length() < 2 || request.nickname().length() > 10) {
+            throw new CustomException(UserErrorCode.INVALID_NICKNAME_LENGTH);
+        }
+
         // 정보 수정
         user.updateInfo(
                 request.nickname(),

--- a/src/main/java/com/example/RealMatch/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/RealMatch/user/domain/repository/UserRepository.java
@@ -13,9 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.id = :id and u.isDeleted = false")
     Optional<User> findById(@Param("id") Long id);
 
-    // 이메일로 조회 (Spring Security 인증 시 주로 사용)
-    @Query("select u from User u where u.email = :email and u.isDeleted = false")
-    Optional<User> findByEmail(@Param("email") String email);
-
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/RealMatch/user/presentation/code/UserErrorCode.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/code/UserErrorCode.java
@@ -107,6 +107,18 @@ public enum UserErrorCode implements BaseErrorCode {
             HttpStatus.BAD_REQUEST,
             "USER400_5",
             "탈퇴 처리에 실패했습니다. 다시 시도해주세요."
+    ),
+
+    INVALID_NICKNAME_FORMAT(
+            HttpStatus.BAD_REQUEST,
+            "USER400_6",
+            "닉네임은 한글, 영문, 숫자만 사용 가능합니다."
+    ),
+
+    INVALID_NICKNAME_LENGTH(
+            HttpStatus.BAD_REQUEST,
+            "USER400_7",
+            "닉네임은 2~10자 사이여야 합니다."
     );
 
     private final HttpStatus status;


### PR DESCRIPTION
## Summary
닉네임 로직 구현을 위해 서비스, 예외처리를 구현하고, UserRepository에 메서드들을 알맞게 정리했습니다.
스웨거 문서도 재정리했습니다.


## Changes
UserService에 updateMyInfo 메서드 예외처리구현
AuthService에 validateNickname 메서드 예외처리 구현
OAuthErrorCode, UserErrorCode 예외처리 상세구현
UserRepository 메서드 정리


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [x] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
Closes #193

## 참고 사항
기능 구현 말고도 추가로 UserRepository 에서 안쓰는 메서드 삭제/정리 했고, DTO swagger example도 기능에 영향없는 진짜 간단한 배열 숫자만 변경했습니다.