### PR TITLE
feat(#198): Campaign과 CampaignProposal 엔티티에 필드 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
+++ b/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
@@ -51,8 +51,11 @@ public class CampaignProposal extends BaseEntity {
     @Column(name = "who_proposed", nullable = false, length = 20)
     private Role whoProposed;
 
-    @Column(name = "proposed_user_id", nullable = false)
-    private Long proposedUserId;
+    @Column(name = "sender_user_id", nullable = false)
+    private Long senderUserId;
+
+    @Column(name = "receiver_user_id", nullable = false)
+    private Long receiverUserId;
 
     // 기존 캠페인 기반 제안이면 참조
     @ManyToOne(fetch = FetchType.LAZY)
@@ -100,7 +103,8 @@ public class CampaignProposal extends BaseEntity {
             User creator,
             Brand brand,
             Role whoProposed,
-            Long proposedUserId,
+            Long senderUserId,
+            Long receiverUserId,
             Campaign campaign,
             String title,
             String campaignDescription,
@@ -112,7 +116,8 @@ public class CampaignProposal extends BaseEntity {
         this.creator = creator;
         this.brand = brand;
         this.whoProposed = whoProposed;
-        this.proposedUserId = proposedUserId;
+        this.senderUserId = senderUserId;
+        this.receiverUserId = receiverUserId;
         this.campaign = campaign;
         this.title = title;
         this.campaignDescription = campaignDescription;

--- a/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
+++ b/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
@@ -20,9 +20,11 @@ public enum BusinessErrorCode implements BaseErrorCode {
     CAMPAIGN_PROPOSAL_CREATOR_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CREATOR_PROPOSAL_400_3", "캠페인 제안에 크리에이터는 변경할 수 없습니다."),
     CAMPAIGN_PROPOSAL_CAMPAIGN_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_4", "캠페인 제안에 연결된 캠페인은 변경할 수 없습니다."),
     CAMPAIGN_PROPOSAL_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_5", "캠페인 제작 시작 날짜가 마감 날짜보나 늦을 수 없습니다."),
-    CAMPAIGN_PROPOSAL_FORBIDDEN(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_1", "해당 캠페인 제안을 수정할 권한이 없습니다."),
+    CAMPAIGN_PROPOSAL_NOT_REVIEWING(HttpStatus.BAD_REQUEST,"BUSINESS_CAMPAIGN_PROPOSAL_400_6", "검토중인 캠페인이 아닙니다."),
+    CAMPAIGN_PROPOSAL_FORBIDDEN(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_1", "해당 캠페인 제안에 대한 권한이 없습니다."),
     CAMPAIGN_PROPOSAL_ROLE_MISMATCH(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_2", "캠페인 제안 주체와 요청자의 역할이 일치하지 않습니다."),
     CAMPAIGN_PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_CAMPAIGN_PROPOSAL_404_2", "캠페인 제안 내역이 없습니다.");
+
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
+++ b/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
@@ -20,15 +20,12 @@ public enum BusinessErrorCode implements BaseErrorCode {
     CAMPAIGN_PROPOSAL_CREATOR_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CREATOR_PROPOSAL_400_3", "캠페인 제안에 크리에이터는 변경할 수 없습니다."),
     CAMPAIGN_PROPOSAL_CAMPAIGN_IMMUTABLE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_4", "캠페인 제안에 연결된 캠페인은 변경할 수 없습니다."),
     CAMPAIGN_PROPOSAL_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_5", "캠페인 제작 시작 날짜가 마감 날짜보나 늦을 수 없습니다."),
-    CAMPAIGN_PROPOSAL_NOT_REVIEWING(HttpStatus.BAD_REQUEST,"BUSINESS_CAMPAIGN_PROPOSAL_400_6", "검토중인 캠페인이 아닙니다."),
+    CAMPAIGN_PROPOSAL_NOT_REVIEWING(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_6", "검토중인 캠페인이 아닙니다."),
     CAMPAIGN_PROPOSAL_FORBIDDEN(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_1", "해당 캠페인 제안에 대한 권한이 없습니다."),
     CAMPAIGN_PROPOSAL_ROLE_MISMATCH(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_2", "캠페인 제안 주체와 요청자의 역할이 일치하지 않습니다."),
     CAMPAIGN_PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_CAMPAIGN_PROPOSAL_404_2", "캠페인 제안 내역이 없습니다.");
 
-
-
     private final HttpStatus status;
     private final String code;
     private final String message;
-
 }

--- a/src/main/java/com/example/RealMatch/business/presentation/swagger/CampaignProposalSwagger.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/swagger/CampaignProposalSwagger.java
@@ -46,17 +46,17 @@ public interface CampaignProposalSwagger {
                                         { "id": 1 }
                                       ],
                                       "categories": [
-                                        { "id": 2, "customValue": "성분 분석 리뷰" }
+                                        { "id": 11, "customValue": "성분 분석 리뷰" }
                                       ],
                                       "tones": [
-                                        { "id": 3 },
-                                        { "id": 4 }
+                                        { "id": 12 },
+                                        { "id": 13 }
                                       ],
                                       "involvements": [
-                                        { "id": 5 }
+                                        { "id": 20 }
                                       ],
                                       "usageRanges": [
-                                        { "id": 6 }
+                                        { "id": 25 }
                                       ],
                                       "rewardAmount": 200000,
                                       "productId": 5,
@@ -100,17 +100,17 @@ public interface CampaignProposalSwagger {
                                         { "id": 1 }
                                       ],
                                       "categories": [
-                                        { "id": 2, "customValue": "성분 분석 리뷰" },
-                                        { "id": 7 }
-                                      ],
-                                      "tones": [
-                                        { "id": 3 }
-                                      ],
-                                      "involvements": [
+                                        { "id": 11, "customValue": "성분 분석 리뷰" },
                                         { "id": 5 }
                                       ],
+                                      "tones": [
+                                        { "id": 12 }
+                                      ],
+                                      "involvements": [
+                                        { "id": 21 }
+                                      ],
                                       "usageRanges": [
-                                        { "id": 6 }
+                                        { "id": 26 }
                                       ],
                                       "rewardAmount": 100000,
                                       "productId": 5,

--- a/src/main/java/com/example/RealMatch/campaign/domain/entity/Campaign.java
+++ b/src/main/java/com/example/RealMatch/campaign/domain/entity/Campaign.java
@@ -100,11 +100,38 @@ public class Campaign extends DeleteBaseEntity {
     private Long createdBy;
 
     @Builder
-    public Campaign(String title, String description, String preferredSkills, String schedule, String videoSpec,
-                    String product, Long rewardAmount, CampaignOriginType originType,
-                    LocalDate startDate, LocalDate endDate,
-                    LocalDateTime recruitStartDate, LocalDateTime recruitEndDate,
-                    Integer quota, Long createdBy) {
+    public Campaign(
+            Brand brand,
+            String title,
+            String description,
+            String preferredSkills,
+            String schedule,
+            String videoSpec,
+            String product,
+            Long rewardAmount,
+            String imageUrl,
+            Long proposalId,
+            CampaignOriginType originType,
+            LocalDate startDate,
+            LocalDate endDate,
+            LocalDateTime recruitStartDate,
+            LocalDateTime recruitEndDate,
+            Integer quota,
+            Long createdBy
+    ) {
+        if (originType == CampaignOriginType.PROPOSAL && proposalId == null) {
+            throw new IllegalArgumentException(
+                    "originType이 PROPOSAL이면 proposalId는 필수입니다."
+            );
+        }
+
+        if (originType == CampaignOriginType.DIRECT && proposalId != null) {
+            throw new IllegalArgumentException(
+                    "DIRECT 캠페인은 proposalId를 가질 수 없습니다."
+            );
+        }
+
+        this.brand = brand;
         this.title = title;
         this.description = description;
         this.preferredSkills = preferredSkills;
@@ -112,6 +139,8 @@ public class Campaign extends DeleteBaseEntity {
         this.videoSpec = videoSpec;
         this.product = product;
         this.rewardAmount = rewardAmount;
+        this.imageUrl = imageUrl;
+        this.proposalId = proposalId;
         this.originType = originType;
         this.status = CampaignStatus.DRAFT;
         this.startDate = startDate;

--- a/src/main/java/com/example/RealMatch/campaign/domain/enums/CampaignOriginType.java
+++ b/src/main/java/com/example/RealMatch/campaign/domain/enums/CampaignOriginType.java
@@ -1,0 +1,7 @@
+package com.example.RealMatch.campaign.domain.enums;
+
+public enum CampaignOriginType {
+    DIRECT,     // 브랜드가 직접 생성
+    PROPOSAL    // 캠페인 제안(MATCHED)으로 생성
+}
+

--- a/src/main/java/com/example/RealMatch/campaign/domain/enums/CampaignStatus.java
+++ b/src/main/java/com/example/RealMatch/campaign/domain/enums/CampaignStatus.java
@@ -1,0 +1,9 @@
+package com.example.RealMatch.campaign.domain.enums;
+
+public enum CampaignStatus {
+    DRAFT,        // 생성만 됨 (proposal → 막 생성)
+    ACTIVE,       // 실제 진행 중
+    COMPLETED,    // 캠페인 종료
+    CANCELLED     // 중간 취소
+}
+


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
feat(#198): Campaign과 CampaignProposal 엔티티에 필드 추가

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
Campaign과 CampaignProposal 엔티티에 필드를 추가했다.


## Changes
Campaign 엔티티에서 수정사항
```java
    @Column(name = "proposal_id")
    private Long proposalId;  // PROPOSAL이면 반드시 값 존재

    @Enumerated(EnumType.STRING)
    @Column(name = "origin_type", nullable = false, length = 30)
    private CampaignOriginType originType;

    @Enumerated(EnumType.STRING)
    @Column(name = "status", nullable = false, length = 30)
    private CampaignStatus status;

```

CampaignProposal에서 수정사항
proposedUserId → senderUserId로 이름 변경
```java
    @Column(name = "sender_user_id", nullable = false)
    private Long senderUserId;

    @Column(name = "receiver_user_id", nullable = false)
    private Long receiverUserId;
```


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [x] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->

## 참고 사항
@Yoonchulchung 
엔티티 필드 추가로 인해 자동 데이터 만들기 시 수정이 필요합니다. 
originType = DIRECT
status = DRAFT
proposalId는 null 로 데이터 추가하면 됩니다.

기존 proposedUserId → senderUserId로 이름 변경하였고, receiverUserId 필드가 추가되었습니다. 
원래는 로직에 맞춰 제안 보낸 사람과 받은 사람 데이터가 맞춰서 들어가야하지만, 더미 데이터 유저로 로그인 하는 사람이 없기 떄문에,
그냥 더미로 아무 값이나 넣으면 될것 같습니다.



