### PR TITLE
fix(#228): proxy가 헬스체크 못하는 문제 해결

### DIFF
--- a/src/main/java/com/example/RealMatch/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/RealMatch/global/config/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/v3/api-docs",
             "/swagger-ui",
             "/swagger-ui.html",
-            "/swagger-resources"
+            "/swagger-resources",
+            "/actuator"
     );
 
     @Override


### PR DESCRIPTION
## Summary
인증 부분에서 "/actuator"가 추가되어 있지 않아서 프록시가 스프링 상태를 확인하지 못하는 문제 해결

## Changes
- src/main/java/com/example/RealMatch/global/config/jwt/JwtAuthenticationFilter.java 에 "/acutator" 추가

## Type of Change
- [X] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
#228 