### PR TITLE
fix(#223): 매칭 후 반환에서 username과 user type 이미지가 나오도록 변경

### DIFF
--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -98,8 +98,14 @@ public class MatchServiceImpl implements MatchService {
         List<CampaignMatchResult> campaignResults = findMatchingCampaignResults(userDoc, userId);
         saveMatchHistory(userId, brandResults, campaignResults);
 
+        String username = userRepository.findById(userId)
+                .map(User::getName)
+                .orElse("사용자");
+
         return MatchResponseDto.builder()
+                .username(username)
                 .userType(userType)
+                .userTypeImage("https://ui-avatars.com/api/?name=" + userType + "&background=6366f1&color=fff&size=200")
                 .typeTag(typeTag)
                 .highMatchingBrandList(brandListDto)
                 .build();

--- a/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchResponseDto.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchResponseDto.java
@@ -13,7 +13,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MatchResponseDto {
 
+    private String username;
     private String userType;
+    private String userTypeImage;
     private List<String> typeTag;
     private HighMatchingBrandListDto highMatchingBrandList;
 


### PR DESCRIPTION
## Summary
매칭 후 반환에서 username과 user type 이미지가 나오도록 변경

## Changes
- src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
- src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchResponseDto.java

## Type of Change
- [X] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
#223 