### PR TITLE
[FIX] 프론트엔드 url 수정 (#248)

### DIFF
--- a/src/main/java/com/example/RealMatch/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/RealMatch/global/config/SecurityConfig.java
@@ -97,7 +97,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(allowedOrigin, "http://localhost:8080", swaggerUrl, frontDomainUrl, "https://www.realmatch.co.kr", "http://localhost:5173"));
+        configuration.setAllowedOrigins(List.of(allowedOrigin, "http://localhost:8080", swaggerUrl, frontDomainUrl,"https://www.realmatch.co.kr"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/example/RealMatch/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/RealMatch/global/config/SecurityConfig.java
@@ -97,7 +97,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(allowedOrigin, "http://localhost:8080", swaggerUrl, frontDomainUrl,"https://www.realmatch.co.kr"));
+        configuration.setAllowedOrigins(List.of(allowedOrigin, "http://localhost:8080", swaggerUrl, frontDomainUrl, "https://www.realmatch.co.kr"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/example/RealMatch/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/RealMatch/oauth/handler/OAuth2SuccessHandler.java
@@ -22,7 +22,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
 
-    @Value("${front.domain-url}:http://localhost:8080}")
+    @Value("${front.domain-url:http://localhost:8080}")
     private String frontendBaseUrl;
 
     @Override

--- a/src/main/java/com/example/RealMatch/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/RealMatch/oauth/handler/OAuth2SuccessHandler.java
@@ -22,7 +22,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
 
-    @Value("${oauth.redirect.base-url:https://realmatch.co.kr}")
+    @Value("${front.domain-url}:http://localhost:8080}")
     private String frontendBaseUrl;
 
     @Override


### PR DESCRIPTION
## Summary
배포환경에서는 https://realmatch.co.kr로 읽히고 로컬에서는 localhost:8080으로 읽히게 수정


## Changes
front.domain-url수정


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
Fixes #248 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->