### PR TITLE
feat(#156): 받은 캠페인 제안 거절 기능 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
@@ -141,6 +141,30 @@ public class CampaignProposalService {
         publishProposalStatusChangedEvent(proposal, ProposalStatus.MATCHED);
     }
 
+    public void rejectCampaignProposal(
+            Long userId,
+            Long campaignProposalId,
+            String rejectReason
+    ) {
+        CampaignProposal proposal = campaignProposalRepository
+                .findById(campaignProposalId)
+                .orElseThrow(() ->
+                        new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_NOT_FOUND)
+                );
+        validateReceiver(proposal, userId);
+
+        if (proposal.getStatus() != ProposalStatus.REVIEWING) {
+            throw new CustomException(
+                    BusinessErrorCode.CAMPAIGN_PROPOSAL_NOT_REVIEWING
+            );
+        }
+        proposal.reject(rejectReason);
+
+        // 4. 상태 변경 이벤트 발행
+        publishProposalStatusChangedEvent(proposal, ProposalStatus.REJECTED);
+    }
+
+
 
     private void saveAllContentTags(CampaignProposalRequestDto request, CampaignProposal proposal) {
         saveContentTags(proposal, request.getFormats());

--- a/src/main/java/com/example/RealMatch/business/presentation/controller/CampaignProposalController.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/controller/CampaignProposalController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.RealMatch.business.application.service.CampaignProposalQueryService;
 import com.example.RealMatch.business.application.service.CampaignProposalService;
+import com.example.RealMatch.business.presentation.dto.request.CampaignProposalRejectRequest;
 import com.example.RealMatch.business.presentation.dto.request.CampaignProposalRequestDto;
 import com.example.RealMatch.business.presentation.dto.response.CampaignProposalDetailResponse;
 import com.example.RealMatch.business.presentation.swagger.CampaignProposalSwagger;
@@ -78,6 +79,23 @@ public class CampaignProposalController implements CampaignProposalSwagger {
 
         return CustomResponse.ok("캠페인 제안을 수락했습니다.");
     }
+
+    @Override
+    @PatchMapping("/{campaignProposalId}/reject")
+    public CustomResponse<String> rejectCampaignProposal(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long campaignProposalId,
+            @RequestBody(required = false) @Valid CampaignProposalRejectRequest request
+    ) {
+        campaignProposalService.rejectCampaignProposal(
+                userDetails.getUserId(),
+                campaignProposalId,
+                request != null ? request.getRejectReason() : null
+        );
+
+        return CustomResponse.ok("캠페인 제안을 거절했습니다.");
+    }
+
 
 
 }

--- a/src/main/java/com/example/RealMatch/business/presentation/dto/request/CampaignProposalRejectRequest.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/dto/request/CampaignProposalRejectRequest.java
@@ -1,0 +1,13 @@
+package com.example.RealMatch.business.presentation.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CampaignProposalRejectRequest {
+
+    @Size(max = 500, message = "거절 사유는 최대 500자까지 입력할 수 있습니다.")
+    private String rejectReason;
+}

--- a/src/main/java/com/example/RealMatch/business/presentation/swagger/CampaignProposalSwagger.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/swagger/CampaignProposalSwagger.java
@@ -3,6 +3,7 @@ package com.example.RealMatch.business.presentation.swagger;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import com.example.RealMatch.business.presentation.dto.request.CampaignProposalRejectRequest;
 import com.example.RealMatch.business.presentation.dto.request.CampaignProposalRequestDto;
 import com.example.RealMatch.business.presentation.dto.response.CampaignProposalDetailResponse;
 import com.example.RealMatch.global.config.jwt.CustomUserDetails;
@@ -160,6 +161,19 @@ public interface CampaignProposalSwagger {
     CustomResponse<String> approveCampaignProposal(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long campaignProposalId
+    );
+
+    @Operation(
+            summary = "받은 캠페인 제안 거절 API by 박지영",
+            description = """
+                    제안 받은 사람이 제안을 거절하는 API입니다.   
+                    /api/v1/campaigns/proposal/{campaignProposalId}에서 status가 REJECTED로 변경되었다면 성공입니다.
+                    """
+    )
+    CustomResponse<String> rejectCampaignProposal(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long campaignProposalId,
+            @RequestBody(required = false) @Valid CampaignProposalRejectRequest request
     );
 
 }


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
받은 캠페인 제안 거절 기능 추가


## Changes
- [x] 받은 캠페인 제안 거절 API 추가


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
#156 

## 참고 사항
status가 REJECTED로 변경되었다면 성공입니다.