### PR TITLE
feat(#156): 캠페인 제안 취소 기능 추가 및 지원 응답에 apply_id 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignApplyQueryService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignApplyQueryService.java
@@ -28,6 +28,7 @@ public class CampaignApplyQueryService {
 
         return new CampaignApplyDetailResponse(
                 apply.getCampaign().getId(),
+                apply.getId(),
                 apply.getCampaign().getTitle(),
                 apply.getReason(),
                 apply.getApplyStatus()

--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
@@ -236,7 +236,7 @@ public class CampaignProposalService {
                 );
 
 
-        proposal.isCancelable(userId);
+        proposal.validateCancelable(userId);
         proposal.cancel();
 
         publishProposalStatusChangedEvent(proposal, ProposalStatus.CANCELED, userId);

--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
@@ -228,6 +228,21 @@ public class CampaignProposalService {
         throw new CustomException(GeneralErrorCode.INVALID_DATA);
     }
 
+    public void cancelCampaignProposal(Long userId, Long campaignProposalId) {
+        CampaignProposal proposal = campaignProposalRepository
+                .findById(campaignProposalId)
+                .orElseThrow(() ->
+                        new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_NOT_FOUND)
+                );
+
+
+        proposal.isCancelable(userId);
+        proposal.cancel();
+
+        publishProposalStatusChangedEvent(proposal, ProposalStatus.CANCELED, userId);
+    }
+
+
     private void validateReceiver(CampaignProposal proposal, Long userId) {
         if (!proposal.getReceiverUserId().equals(userId)) {
             throw new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_FORBIDDEN);

--- a/src/main/java/com/example/RealMatch/business/domain/entity/CampaignApply.java
+++ b/src/main/java/com/example/RealMatch/business/domain/entity/CampaignApply.java
@@ -48,7 +48,7 @@ public class CampaignApply extends BaseEntity {
     @JoinColumn(name = "campaign_id", nullable = false)
     private Campaign campaign;
 
-    @Column(nullable = false)
+    @Column(name = "apply_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private ProposalStatus applyStatus;
 

--- a/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
+++ b/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
@@ -6,8 +6,10 @@ import java.util.List;
 
 import com.example.RealMatch.brand.domain.entity.Brand;
 import com.example.RealMatch.business.domain.enums.ProposalStatus;
+import com.example.RealMatch.business.exception.BusinessErrorCode;
 import com.example.RealMatch.campaign.domain.entity.Campaign;
 import com.example.RealMatch.global.common.BaseEntity;
+import com.example.RealMatch.global.exception.CustomException;
 import com.example.RealMatch.user.domain.entity.User;
 import com.example.RealMatch.user.domain.entity.enums.Role;
 
@@ -170,8 +172,24 @@ public class CampaignProposal extends BaseEntity {
         this.refusalReason = refusalReason;
     }
 
-    // TODO: 제안 취소 기능 구현 필요
-    // 제안을 제시한 유저(senderUserId)가 자신의 제안을 취소할 수 있어야 함
+    public void cancel() {
+        this.status = ProposalStatus.CANCELED;
+    }
+
+    public void isCancelable(Long userId) {
+        if (!this.senderUserId.equals(userId)) {
+            throw new CustomException(
+                    BusinessErrorCode.CAMPAIGN_PROPOSAL_USER_MISMATCH
+            );
+        }
+
+        if (this.status != ProposalStatus.REVIEWING) {
+            throw new CustomException(
+                    BusinessErrorCode.CAMPAIGN_PROPOSAL_NOT_REVIEWING
+            );
+        }
+    }
+
 
     public void addTag(CampaignProposalContentTag tag) {
         this.tags.add(tag);

--- a/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
+++ b/src/main/java/com/example/RealMatch/business/domain/entity/CampaignProposal.java
@@ -176,7 +176,7 @@ public class CampaignProposal extends BaseEntity {
         this.status = ProposalStatus.CANCELED;
     }
 
-    public void isCancelable(Long userId) {
+    public void validateCancelable(Long userId) {
         if (!this.senderUserId.equals(userId)) {
             throw new CustomException(
                     BusinessErrorCode.CAMPAIGN_PROPOSAL_USER_MISMATCH

--- a/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
+++ b/src/main/java/com/example/RealMatch/business/exception/BusinessErrorCode.java
@@ -25,6 +25,7 @@ public enum BusinessErrorCode implements BaseErrorCode {
     CAMPAIGN_PROPOSAL_NOT_REVIEWING(HttpStatus.BAD_REQUEST, "BUSINESS_CAMPAIGN_PROPOSAL_400_6", "검토중인 캠페인이 아닙니다."),
     CAMPAIGN_PROPOSAL_FORBIDDEN(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_1", "해당 캠페인 제안에 대한 권한이 없습니다."),
     CAMPAIGN_PROPOSAL_ROLE_MISMATCH(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_2", "캠페인 제안 주체와 요청자의 역할이 일치하지 않습니다."),
+    CAMPAIGN_PROPOSAL_USER_MISMATCH(HttpStatus.FORBIDDEN, "BUSINESS_CAMPAIGN_PROPOSAL_403_3", "캠페인 제안 주체와 요청자가 일치하지 않습니다."),
     CAMPAIGN_PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_CAMPAIGN_PROPOSAL_404_2", "캠페인 제안 내역이 없습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/example/RealMatch/business/presentation/controller/CampaignProposalController.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/controller/CampaignProposalController.java
@@ -96,6 +96,21 @@ public class CampaignProposalController implements CampaignProposalSwagger {
         return CustomResponse.ok("캠페인 제안을 거절했습니다.");
     }
 
+    @Override
+    @PatchMapping("/{campaignProposalId}/cancel")
+    public CustomResponse<String> cancelCampaignProposal(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long campaignProposalId
+    ) {
+        campaignProposalService.cancelCampaignProposal(
+                userDetails.getUserId(),
+                campaignProposalId
+        );
+
+        return CustomResponse.ok("캠페인 제안을 취소했습니다.");
+    }
+
+
 
 
 }

--- a/src/main/java/com/example/RealMatch/business/presentation/dto/response/CampaignApplyDetailResponse.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/dto/response/CampaignApplyDetailResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class CampaignApplyDetailResponse {
 
     private Long campaignId;
+    private Long campaignApplyId;
     private String campaignTitle;
     private String campaignReason;
     private ProposalStatus status;

--- a/src/main/java/com/example/RealMatch/business/presentation/swagger/CampaignProposalSwagger.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/swagger/CampaignProposalSwagger.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 
 public interface CampaignProposalSwagger {
@@ -175,5 +177,56 @@ public interface CampaignProposalSwagger {
             @PathVariable Long campaignProposalId,
             @RequestBody(required = false) @Valid CampaignProposalRejectRequest request
     );
+
+    @Operation(
+            summary = "캠페인 제안 취소 API by 박지영",
+            description = """
+                사용자가 보낸 캠페인 제안을 취소합니다.   
+                
+                - 제안 상태가 REVIEWING 인 경우에만 취소할 수 있습니다.    
+                - 이미 수락되었거나 거절된 제안은 취소할 수 없습니다.   
+                
+                /api/v1/campaigns/proposal/{campaignProposalId}에서 status가 CANCELED로 바뀌었는지 확인해주세요. 
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200",
+                    description = "캠페인 제안 취소 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                {
+                                  "isSuccess": true,
+                                  "code": "COMMON200_1",
+                                  "message": "정상적인 요청입니다.",
+                                  "result": "캠페인 제안을 취소했습니다."
+                                }
+                                """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "BUSINESS_CAMPAIGN_PROPOSAL_400_6 - 검토중인 캠페인이 아님",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "BUSINESS_CAMPAIGN_PROPOSAL_403_3 - 제안 취소 권한 없음",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "BUSINESS_CAMPAIGN_PROPOSAL_404_2 - 캠페인 제안 없음",
+                    content = @Content
+            )
+    })
+    CustomResponse<String> cancelCampaignProposal(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long campaignProposalId
+    );
+
 
 }


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
feat(#156): 캠페인 제안 취소 기능 추가 및 지원 응답에 apply_id 추가

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
캠페인 제안 취소 기능 추가 및 지원 응답에 apply_id 추가

## Changes
- [x] 캠페인 제안 취소 기능 추가
- [x] 캠페인 지원 조회 응답에 apply_id 추가
<img width="312" height="120" alt="image" src="https://github.com/user-attachments/assets/1d4f826f-fa67-4822-b930-fb6c9545698b" />




## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
closed: #156 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->