### PR TITLE
fix(#279): 브랜드 조회 문제 해결

### DIFF
--- a/src/main/java/com/example/RealMatch/brand/application/service/BrandService.java
+++ b/src/main/java/com/example/RealMatch/brand/application/service/BrandService.java
@@ -87,7 +87,7 @@ public class BrandService {
         boolean isLiked = brandLikeRepository.existsByUserIdAndBrandId(currentUserId, brandId);
 
         // 사용자 맞춤 브랜드 매칭률 조회
-        Long brandMatchingRatio = matchBrandHistoryRepository.findByUserIdAndBrandId(currentUserId, brandId)
+        Long brandMatchingRatio = matchBrandHistoryRepository.findByUserIdAndBrandIdAndIsDeprecatedFalse(currentUserId, brandId)
                 .map(history -> history.getMatchingRatio())
                 .orElse(0L);
 

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
@@ -20,6 +20,8 @@ public interface MatchBrandHistoryRepository extends JpaRepository<MatchBrandHis
 
     Optional<MatchBrandHistory> findByUserIdAndBrandId(Long userId, Long brandId);
 
+    Optional<MatchBrandHistory> findByUserIdAndBrandIdAndIsDeprecatedFalse(Long userId, Long brandId);
+
     List<MatchBrandHistory> findByUserIdOrderByMatchingRatioDesc(Long userId);
 
     List<MatchBrandHistory> findByUserIdAndIsDeprecatedFalse(Long userId);


### PR DESCRIPTION
## Summary
- 브랜드 상세 조회에서 매칭 히스토리를 통해 매칭률 조회에서 문제 발생  
  - isDeprecated가 False로 된 것들만 조회를 해야 하는데, 그렇게 로직이 작성되어 있지 못했음.  
- 매칭 후 브랜드 조회에서 발생하는 브랜드 상세 태그 조회 매핑 해결


## Changes
- 브랜드 조회에서 발생하는 매칭률 반환 문제 해결
- 브랜드 상세 카테고리 조회 가능 


## Type of Change
- [X] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
#279 #278 