### PR TITLE
[FEAT] 브랜드 상세 이미지 다중 처리 및 조회 기능 구현 (#281)

### DIFF
--- a/src/main/java/com/example/RealMatch/brand/application/service/BrandService.java
+++ b/src/main/java/com/example/RealMatch/brand/application/service/BrandService.java
@@ -304,6 +304,17 @@ public class BrandService {
         // 브랜드 먼저 저장
         Brand savedBrand = brandRepository.save(brand);
 
+        // 브랜드 이미지 저장
+        if (requestDto.getBrandImages() != null && !requestDto.getBrandImages().isEmpty()) {
+            List<BrandImage> brandImages = requestDto.getBrandImages().stream()
+                    .map(imageUrl -> BrandImage.builder()
+                            .brand(savedBrand)
+                            .imageUrl(imageUrl)
+                            .build())
+                    .collect(Collectors.toList());
+            brandImageRepository.saveAll(brandImages);
+        }
+
         // *** 브랜드 매칭용/상세 페이지용 뷰티 태그 추가 *** //
         if (requestDto.getBrandTags() != null) {
             BrandBeautyCreateRequestDto.BrandTagsDto brandTags = requestDto.getBrandTags();
@@ -355,6 +366,17 @@ public class BrandService {
 
         // 브랜드 먼저 저장
         Brand savedBrand = brandRepository.save(brand);
+
+        // 브랜드 이미지 저장
+        if (requestDto.getBrandImages() != null && !requestDto.getBrandImages().isEmpty()) {
+            List<BrandImage> brandImages = requestDto.getBrandImages().stream()
+                    .map(imageUrl -> BrandImage.builder()
+                            .brand(savedBrand)
+                            .imageUrl(imageUrl)
+                            .build())
+                    .collect(Collectors.toList());
+            brandImageRepository.saveAll(brandImages);
+        }
 
         // *** 브랜드 매칭용/상세 페이지용 패션 태그 추가 *** //
         if (requestDto.getBrandTags() != null) {


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
브랜드 상세 페이지와 생성 프로세스에서 여러 개의 이미지를 관리할 수 있도록 Brand와 BrandImage 간의 연관 관계를 구축하고, 관련 API(조회/생성)를 고도화했습니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
1. Entity 연관 관계 설정
- Brand 엔티티 내에 BrandImage와의 @OneToMany 양방향 연관 관계를 설정했습니다.
- 양방향 편의 메서드(addBrandImage)를 추가하여 데이터 정합성을 보장합니다.

2. DTO 필드 추가
- BrandDetailResponseDto: 조회 시 이미지 URL 리스트(brandImages)를 반환하도록 필드를 추가했습니다.
- BrandBeautyCreateRequestDto, BrandFashionCreateRequestDto: 생성 시 여러 이미지 URL을 받을 수 있도록 리스트 필드를 추가했습니다.

3. Service 로직 고도화
- getBrandDetail: brandImageRepository를 통해 해당 브랜드의 모든 상세 이미지를 조회하여 응답에 포함합니다.
- createBeautyBrand, createFashionBrand: 브랜드 저장 후 전달받은 이미지 URL 리스트를 BrandImage 엔티티로 변환하여 일괄 저장하는 로직을 구현했습니다.


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #281 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->