### PR TITLE
[FIX] 채팅방 lastMessage 및 읽음 처리 동시성 문제 해결 및 성능 개선

### DIFF
--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalService.java
@@ -164,11 +164,6 @@ public class CampaignProposalService {
         publishProposalStatusChangedEvent(proposal, ProposalStatus.REJECTED, userId);
     }
 
-    // TODO: 제안 취소 기능 구현 필요
-    // 제안을 제시한 유저가 자신의 제안을 취소할 수 있는 API
-    // 그리고 상태 변경 이벤트 발행 필요
-
-
     private void saveAllContentTags(CampaignProposalRequestDto request, CampaignProposal proposal) {
         saveContentTags(proposal, request.getFormats());
         saveContentTags(proposal, request.getCategories());

--- a/src/main/java/com/example/RealMatch/chat/application/event/ChatMessagesViewedEvent.java
+++ b/src/main/java/com/example/RealMatch/chat/application/event/ChatMessagesViewedEvent.java
@@ -2,6 +2,7 @@ package com.example.RealMatch.chat.application.event;
 
 public record ChatMessagesViewedEvent(
         Long memberId,
+        Long userId,
         Long latestMessageId
 ) {
 }

--- a/src/main/java/com/example/RealMatch/chat/application/event/ChatMessagesViewedEventListener.java
+++ b/src/main/java/com/example/RealMatch/chat/application/event/ChatMessagesViewedEventListener.java
@@ -15,9 +15,9 @@ public class ChatMessagesViewedEventListener {
 
     @EventListener
     public void handle(ChatMessagesViewedEvent event) {
-        if (event.memberId() == null || event.latestMessageId() == null) {
+        if (event.memberId() == null || event.userId() == null || event.latestMessageId() == null) {
             return;
         }
-        chatRoomMemberCommandService.updateLastReadMessage(event.memberId(), event.latestMessageId());
+        chatRoomMemberCommandService.updateLastReadMessage(event.memberId(), event.userId(), event.latestMessageId());
     }
 }

--- a/src/main/java/com/example/RealMatch/chat/application/event/apply/ApplySystemMessageHandler.java
+++ b/src/main/java/com/example/RealMatch/chat/application/event/apply/ApplySystemMessageHandler.java
@@ -158,7 +158,8 @@ public class ApplySystemMessageHandler extends BaseSystemMessageHandler {
                 () -> new ChatApplyStatusNoticePayloadResponse(
                         event.applyId(),
                         event.actorUserId(),
-                        LocalDateTime.now()
+                        LocalDateTime.now(),
+                        event.newStatus()
                 ),
                 payload -> {
                     boolean accepted = retrySender.sendWithIdempotency(

--- a/src/main/java/com/example/RealMatch/chat/application/event/proposal/ProposalSystemMessageHandler.java
+++ b/src/main/java/com/example/RealMatch/chat/application/event/proposal/ProposalSystemMessageHandler.java
@@ -173,7 +173,8 @@ public class ProposalSystemMessageHandler extends BaseSystemMessageHandler {
                 () -> new ChatProposalStatusNoticePayloadResponse(
                         event.proposalId(),
                         event.actorUserId(),
-                        LocalDateTime.now()
+                        LocalDateTime.now(),
+                        event.newStatus()
                 ),
                 payload -> {
                     boolean accepted = retrySender.sendWithIdempotency(

--- a/src/main/java/com/example/RealMatch/chat/application/service/message/ChatMessageQueryServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/message/ChatMessageQueryServiceImpl.java
@@ -63,7 +63,7 @@ public class ChatMessageQueryServiceImpl implements ChatMessageQueryService {
         if (cursorMessageId == null) {
             ChatMessage latestMessage = messages.get(0);
             eventPublisher.publishEvent(
-                    new ChatMessagesViewedEvent(member.getId(), latestMessage.getId())
+                    new ChatMessagesViewedEvent(member.getId(), member.getUserId(), latestMessage.getId())
             );
         }
 

--- a/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomMemberCommandService.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomMemberCommandService.java
@@ -6,5 +6,5 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface ChatRoomMemberCommandService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    void updateLastReadMessage(@NonNull Long memberId, @NonNull Long messageId);
+    void updateLastReadMessage(@NonNull Long memberId, @NonNull Long userId, @NonNull Long messageId);
 }

--- a/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomMemberCommandServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomMemberCommandServiceImpl.java
@@ -2,6 +2,8 @@ package com.example.RealMatch.chat.application.service.room;
 
 import java.time.LocalDateTime;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -9,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.RealMatch.chat.application.cache.ChatCacheInvalidationService;
 import com.example.RealMatch.chat.application.tx.AfterCommitExecutor;
-import com.example.RealMatch.chat.domain.entity.ChatRoomMember;
 import com.example.RealMatch.chat.domain.repository.ChatRoomMemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -18,22 +19,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatRoomMemberCommandServiceImpl implements ChatRoomMemberCommandService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ChatRoomMemberCommandServiceImpl.class);
+
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ChatCacheInvalidationService cacheInvalidationService;
     private final AfterCommitExecutor afterCommitExecutor;
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void updateLastReadMessage(@NonNull Long memberId, @NonNull Long messageId) {
-        ChatRoomMember member = chatRoomMemberRepository.findById(memberId)
-                .orElse(null);
-        if (member == null) {
-            return;
-        }
-        Long currentLastRead = member.getLastReadMessageId();
-        if (currentLastRead == null || currentLastRead < messageId) {
-            member.updateLastReadMessage(messageId, LocalDateTime.now());
-            afterCommitExecutor.execute(() -> cacheInvalidationService.invalidateAfterMemberRead(member.getUserId()));
+    public void updateLastReadMessage(@NonNull Long memberId, @NonNull Long userId, @NonNull Long messageId) {
+        int updatedRows = chatRoomMemberRepository.updateLastReadMessageIfNewer(
+                memberId, messageId, LocalDateTime.now()
+        );
+
+        if (updatedRows == 1) {
+            afterCommitExecutor.execute(() -> cacheInvalidationService.invalidateAfterMemberRead(userId));
+        } else if (updatedRows > 1) {
+            LOG.warn("[ChatRoomMember] Unexpected update count. memberId={}, messageId={}, rows={}",
+                    memberId, messageId, updatedRows);
         }
     }
 }

--- a/src/main/java/com/example/RealMatch/chat/domain/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/RealMatch/chat/domain/repository/ChatRoomMemberRepository.java
@@ -1,9 +1,13 @@
 package com.example.RealMatch.chat.domain.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.RealMatch.chat.domain.entity.ChatRoomMember;
 
@@ -15,4 +19,18 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     List<ChatRoomMember> findByRoomIdIn(List<Long> roomIds);
 
     List<ChatRoomMember> findByRoomId(Long roomId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE ChatRoomMember m
+            SET m.lastReadMessageId = :messageId,
+                m.lastReadAt = :readAt
+            WHERE m.id = :memberId
+              AND (m.lastReadMessageId IS NULL OR m.lastReadMessageId < :messageId)
+            """)
+    int updateLastReadMessageIfNewer(
+            @Param("memberId") Long memberId,
+            @Param("messageId") Long messageId,
+            @Param("readAt") LocalDateTime readAt
+    );
 }

--- a/src/main/java/com/example/RealMatch/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/RealMatch/chat/domain/repository/ChatRoomRepository.java
@@ -1,11 +1,34 @@
 package com.example.RealMatch.chat.domain.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.RealMatch.chat.domain.entity.ChatRoom;
+import com.example.RealMatch.chat.domain.enums.ChatMessageType;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomRepositoryCustom {
     Optional<ChatRoom> findByRoomKey(String roomKey);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE ChatRoom r
+            SET r.lastMessageId = :messageId,
+                r.lastMessageAt = :messageAt,
+                r.lastMessagePreview = :messagePreview,
+                r.lastMessageType = :messageType
+            WHERE r.id = :roomId
+              AND (r.lastMessageAt IS NULL OR r.lastMessageAt < :messageAt)
+            """)
+    int updateLastMessageIfNewer(
+            @Param("roomId") Long roomId,
+            @Param("messageId") Long messageId,
+            @Param("messageAt") LocalDateTime messageAt,
+            @Param("messagePreview") String messagePreview,
+            @Param("messageType") ChatMessageType messageType
+    );
 }

--- a/src/main/java/com/example/RealMatch/chat/presentation/dto/response/ChatApplyStatusNoticePayloadResponse.java
+++ b/src/main/java/com/example/RealMatch/chat/presentation/dto/response/ChatApplyStatusNoticePayloadResponse.java
@@ -2,9 +2,12 @@ package com.example.RealMatch.chat.presentation.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.example.RealMatch.chat.domain.enums.ChatProposalStatus;
+
 public record ChatApplyStatusNoticePayloadResponse(
         Long applyId,
         Long actorUserId,
-        LocalDateTime processedAt
+        LocalDateTime processedAt,
+        ChatProposalStatus applyStatus
 ) implements ChatSystemMessagePayload {
 }

--- a/src/main/java/com/example/RealMatch/chat/presentation/dto/response/ChatProposalStatusNoticePayloadResponse.java
+++ b/src/main/java/com/example/RealMatch/chat/presentation/dto/response/ChatProposalStatusNoticePayloadResponse.java
@@ -2,9 +2,12 @@ package com.example.RealMatch.chat.presentation.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.example.RealMatch.chat.domain.enums.ChatProposalStatus;
+
 public record ChatProposalStatusNoticePayloadResponse(
         Long proposalId,
         Long actorUserId,
-        LocalDateTime processedAt
+        LocalDateTime processedAt,
+        ChatProposalStatus proposalStatus
 ) implements ChatSystemMessagePayload {
 }


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
채팅방 `lastMessage` 업데이트와 읽음 처리에서 발생할 수 있는 Race Condition을 조건부 UPDATE로 해결하고, 불필요한 DB 조회를 제거하여 성능을 개선했습니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
### 1. 동시성 문제 해결
- **채팅방 lastMessage 업데이트 Race Condition 해결**
  - `ChatRoomRepository.updateLastMessageIfNewer()` 추가 (조건부 UPDATE)
  - `WHERE last_message_at IS NULL OR last_message_at < :newLastMessageAt` 조건으로 더 최신 메시지일 때만 업데이트
  - DB 레벨에서 원자적 연산 보장

- **읽음 처리 동시성 문제 해결**
  - `ChatRoomMemberRepository.updateLastReadMessageIfNewer()` 추가 (조건부 UPDATE)
  - `WHERE last_read_message_id IS NULL OR last_read_message_id < :newId` 조건으로 더 큰 메시지 ID일 때만 업데이트
  - 동시 읽음 처리 시에도 항상 최대값 유지

### 2. 성능 개선
- **불필요한 조회 제거**
  - `ChatRoomUpdateServiceImpl.updateLastMessage()`: `existsById()`를 `updatedRows == 0`일 때만 실행
  - `ChatRoomMemberCommandServiceImpl.updateLastReadMessage()`: 성공 시에만 필요한 데이터 조회

- **이벤트에 userId 포함하여 추가 조회 제거**
  - `ChatMessagesViewedEvent`에 `userId` 필드 추가
  - 호출부에서 이미 조회한 `member.getUserId()`를 이벤트에 포함
  - 성공 케이스에서 `findById()` 조회 제거 (SELECT 1회 제거)

### 3. 코드 개선
- 빈 분기 제거 및 guard clause 적용으로 가독성 향상
- `@Modifying(clearAutomatically = true, flushAutomatically = true)` 추가로 영속성 컨텍스트 정합성 보장
- `messageAt` null 방어 로직 추가

## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [x] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #285 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->