### PR TITLE
fix(#291): 매칭 후 켐페인 조회 응답에 campaignId 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/campaign/domain/repository/CampaignLikeRepository.java
+++ b/src/main/java/com/example/RealMatch/campaign/domain/repository/CampaignLikeRepository.java
@@ -34,4 +34,12 @@ public interface CampaignLikeRepository extends JpaRepository<CampaignLike, Long
     );
 
     long countByCampaignId(Long campaignId);
+
+    @Query("""
+        select cl.campaign.id, count(cl)
+        from CampaignLike cl
+        where cl.campaign.id in :campaignIds
+        group by cl.campaign.id
+    """)
+    List<Object[]> countByCampaignIdIn(@Param("campaignIds") List<Long> campaignIds);
 }

--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -569,6 +569,7 @@ public class MatchServiceImpl implements MatchService {
                 .brandMatchingRatio(matchRatio)
                 .brandIsLiked(likedCampaignIds.contains(campaign.getId()))
                 .brandIsRecruiting(isRecruiting)
+                .campaignId(campaign.getId())
                 .campaignManuscriptFee(campaign.getRewardAmount() != null ? campaign.getRewardAmount().intValue() : null)
                 .campaignName(campaign.getTitle())
                 .campaignDDay(Math.max(dDay, 0))

--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -559,6 +559,11 @@ public class MatchServiceImpl implements MatchService {
         int dDay = campaign.getRecruitEndDate() != null
                 ? (int) ChronoUnit.DAYS.between(LocalDate.now(), campaign.getRecruitEndDate().toLocalDate())
                 : 0;
+
+        Set<Long> likedBrandIds = brandLikeRepository.findByUserId(userIdLong).stream()
+                                                     .map(like -> like.getBrand().getId())
+                                                     .collect(Collectors.toSet());
+
         boolean isRecruiting = campaign.getRecruitEndDate() == null
                 || campaign.getRecruitEndDate().isAfter(LocalDateTime.now());
         Integer matchRatio = history.getMatchingRatio() != null ? history.getMatchingRatio().intValue() : 0;
@@ -567,7 +572,7 @@ public class MatchServiceImpl implements MatchService {
                 .brandName(brand != null ? brand.getBrandName() : null)
                 .brandLogoUrl(brand != null ? brand.getLogoUrl() : null)
                 .brandMatchingRatio(matchRatio)
-                .brandIsLiked(likedCampaignIds.contains(campaign.getId()))
+                .brandIsLiked(brand != null && likedBrandIds.contains(brand.getId()))
                 .brandIsRecruiting(isRecruiting)
                 .campaignId(campaign.getId())
                 .campaignManuscriptFee(campaign.getRewardAmount() != null ? campaign.getRewardAmount().intValue() : null)

--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -560,7 +560,7 @@ public class MatchServiceImpl implements MatchService {
                 ? (int) ChronoUnit.DAYS.between(LocalDate.now(), campaign.getRecruitEndDate().toLocalDate())
                 : 0;
 
-        Set<Long> likedBrandIds = brandLikeRepository.findByUserId(userIdLong).stream()
+        Set<Long> likedBrandIds = brandLikeRepository.findByUserId(history.getUser().getId()).stream()
                                                      .map(like -> like.getBrand().getId())
                                                      .collect(Collectors.toSet());
 

--- a/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchCampaignResponseDto.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchCampaignResponseDto.java
@@ -27,6 +27,7 @@ public class MatchCampaignResponseDto {
         private Integer brandMatchingRatio;
         private Boolean brandIsLiked;
         private Boolean brandIsRecruiting;
+        private Long campaignId;
         private Integer campaignManuscriptFee;
         private String campaignName;   // 캠페인명 (keyword 검색 대상)
         private Integer campaignDDay;

--- a/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchCampaignResponseDto.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchCampaignResponseDto.java
@@ -34,6 +34,7 @@ public class MatchCampaignResponseDto {
         private Boolean campaignIsLiked;
         private Integer campaignTotalRecruit;
         private Integer campaignTotalCurrentRecruit;
+        private Long campaignLikeCount;
     }
 
     public static MatchCampaignResponseDto empty() {


### PR DESCRIPTION
## Summary
매칭 후 켐페인 조회 응답에 campaignId가 나오지 않는 문제가 있었음.

매칭 코드에서 dto에 campaignId를 추가해여 응답이 반환될 수 있도록 수정함

## Changes
-
src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
-
src/main/java/com/example/RealMatch/match/presentation/dto/response/MatchCampaignResponseDto.java


## Type of Change
- [X] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
https://github.com/RealMatchTeam/BE/issues/291