### PR TITLE
[FIX] 채팅 opponentName을 브랜드와 크리에이터 분기

### DIFF
--- a/src/main/java/com/example/RealMatch/brand/domain/repository/BrandRepository.java
+++ b/src/main/java/com/example/RealMatch/brand/domain/repository/BrandRepository.java
@@ -33,7 +33,8 @@ public interface BrandRepository extends JpaRepository<Brand, Long> {
     Optional<Brand> findByUserId(@Param("userId") Long userId);
 
     @Query("""
-        select b from Brand b
+        select distinct b from Brand b
+        join fetch b.user
         where b.user.id in :userIds
     """)
     List<Brand> findByUserIdIn(@Param("userIds") List<Long> userIds);

--- a/src/main/java/com/example/RealMatch/brand/domain/repository/BrandRepository.java
+++ b/src/main/java/com/example/RealMatch/brand/domain/repository/BrandRepository.java
@@ -33,6 +33,12 @@ public interface BrandRepository extends JpaRepository<Brand, Long> {
     Optional<Brand> findByUserId(@Param("userId") Long userId);
 
     @Query("""
+        select b from Brand b
+        where b.user.id in :userIds
+    """)
+    List<Brand> findByUserIdIn(@Param("userIds") List<Long> userIds);
+
+    @Query("""
         select b.id
         from Brand b
         where b.brandName like %:keyword%

--- a/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomQueryServiceImpl.java
@@ -167,7 +167,10 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
         // 상대방 멤버 조회 (1:1 채팅방이므로 상대방은 1명)
         ChatRoomMember opponentMember = opponentInfoService.getOpponentMember(roomId, userId);
-        OpponentInfo opponent = opponentInfoService.getOpponentInfo(opponentMember.getUserId());
+        OpponentInfo opponent = opponentInfoService.getOpponentInfo(
+                opponentMember.getUserId(),
+                opponentMember.getRole()
+        );
 
         // 협업중 여부 판단
         boolean isCollaborating = room.isCollaborating();

--- a/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/room/ChatRoomQueryServiceImpl.java
@@ -23,6 +23,7 @@ import com.example.RealMatch.chat.domain.entity.ChatMessage;
 import com.example.RealMatch.chat.domain.entity.ChatRoom;
 import com.example.RealMatch.chat.domain.entity.ChatRoomMember;
 import com.example.RealMatch.chat.domain.enums.ChatRoomFilterStatus;
+import com.example.RealMatch.chat.domain.enums.ChatRoomMemberRole;
 import com.example.RealMatch.chat.domain.enums.ChatSystemMessageKind;
 import com.example.RealMatch.chat.domain.repository.ChatMessageRepository;
 import com.example.RealMatch.chat.domain.repository.ChatRoomMemberRepository;
@@ -151,17 +152,17 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
     @Override
     public ChatRoomDetailResponse getChatRoomDetailWithOpponent(Long userId, Long roomId) {
-        chatRoomMemberService.getActiveMemberOrThrow(roomId, userId);
+        ChatRoomMember myMember = chatRoomMemberService.getActiveMemberOrThrow(roomId, userId);
 
         return chatRoomDetailCache.get(roomId, userId)
                 .orElseGet(() -> {
-                    ChatRoomDetailResponse response = loadChatRoomDetail(userId, roomId);
+                    ChatRoomDetailResponse response = loadChatRoomDetail(userId, roomId, myMember.getRole());
                     chatRoomDetailCache.put(roomId, userId, response);
                     return response;
                 });
     }
 
-    private ChatRoomDetailResponse loadChatRoomDetail(Long userId, Long roomId) {
+    private ChatRoomDetailResponse loadChatRoomDetail(Long userId, Long roomId, ChatRoomMemberRole myRole) {
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ChatErrorCode.ROOM_NOT_FOUND));
 
@@ -190,7 +191,8 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 opponent.profileImageUrl(),
                 isCollaborating,
                 campaignSummary,
-                latestProposalId
+                latestProposalId,
+                myRole
         );
     }
 

--- a/src/main/java/com/example/RealMatch/chat/application/service/room/OpponentInfoService.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/room/OpponentInfoService.java
@@ -4,10 +4,11 @@ import java.util.List;
 import java.util.Map;
 
 import com.example.RealMatch.chat.domain.entity.ChatRoomMember;
+import com.example.RealMatch.chat.domain.enums.ChatRoomMemberRole;
 
 public interface OpponentInfoService {
 
-    OpponentInfo getOpponentInfo(Long opponentUserId);
+    OpponentInfo getOpponentInfo(Long opponentUserId, ChatRoomMemberRole role);
 
     Map<Long, OpponentInfo> getOpponentInfoMapBatch(Long userId, List<Long> roomIds);
 

--- a/src/main/java/com/example/RealMatch/chat/application/service/room/OpponentInfoServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/room/OpponentInfoServiceImpl.java
@@ -12,6 +12,9 @@ import com.example.RealMatch.chat.application.util.ChatConstants;
 import com.example.RealMatch.chat.application.util.ChatRoomValidator;
 import com.example.RealMatch.chat.code.ChatErrorCode;
 import com.example.RealMatch.chat.domain.entity.ChatRoomMember;
+import com.example.RealMatch.chat.domain.enums.ChatRoomMemberRole;
+import com.example.RealMatch.brand.domain.entity.Brand;
+import com.example.RealMatch.brand.domain.repository.BrandRepository;
 import com.example.RealMatch.chat.domain.repository.ChatRoomMemberRepository;
 import com.example.RealMatch.global.exception.CustomException;
 import com.example.RealMatch.user.domain.entity.User;
@@ -25,9 +28,10 @@ public class OpponentInfoServiceImpl implements OpponentInfoService {
 
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final UserRepository userRepository;
+    private final BrandRepository brandRepository;
 
     @Override
-    public OpponentInfo getOpponentInfo(Long opponentUserId) {
+    public OpponentInfo getOpponentInfo(Long opponentUserId, ChatRoomMemberRole role) {
         if (opponentUserId == null) {
             return unknownOpponentInfo(null);
         }
@@ -37,7 +41,12 @@ public class OpponentInfoServiceImpl implements OpponentInfoService {
             return unknownOpponentInfo(opponentUserId);
         }
 
-        return new OpponentInfo(opponentUserId, user.getNickname(), user.getProfileImageUrl());
+        Brand brand = null;
+        if (role == ChatRoomMemberRole.BRAND) {
+            brand = brandRepository.findByUserId(opponentUserId).orElse(null);
+        }
+
+        return toOpponentInfo(opponentUserId, role, user, brand);
     }
 
     @Override
@@ -47,13 +56,14 @@ public class OpponentInfoServiceImpl implements OpponentInfoService {
         }
 
         Map<Long, List<ChatRoomMember>> opponentByRoom = findOpponentMembersByRoom(userId, roomIds);
-        Map<Long, Long> roomToOpponentUserIdMap = buildOpponentUserIdMap(roomIds, opponentByRoom);
-        Map<Long, User> userMap = loadOpponentUsers(roomToOpponentUserIdMap);
+        Map<Long, OpponentMember> roomToOpponentMemberMap = buildOpponentMemberMap(roomIds, opponentByRoom);
+        Map<Long, User> userMap = loadOpponentUsers(roomToOpponentMemberMap);
+        Map<Long, Brand> brandMap = loadOpponentBrands(roomToOpponentMemberMap);
 
         return roomIds.stream()
                 .collect(Collectors.toMap(
                         roomId -> roomId,
-                        roomId -> toOpponentInfo(roomToOpponentUserIdMap.get(roomId), userMap)
+                        roomId -> toOpponentInfo(roomToOpponentMemberMap.get(roomId), userMap, brandMap)
                 ));
     }
 
@@ -73,7 +83,7 @@ public class OpponentInfoServiceImpl implements OpponentInfoService {
                 .collect(Collectors.groupingBy(ChatRoomMember::getRoomId));
     }
 
-    private Map<Long, Long> buildOpponentUserIdMap(
+    private Map<Long, OpponentMember> buildOpponentMemberMap(
             List<Long> roomIds,
             Map<Long, List<ChatRoomMember>> opponentByRoom
     ) {
@@ -83,13 +93,17 @@ public class OpponentInfoServiceImpl implements OpponentInfoService {
                         roomId -> {
                             List<ChatRoomMember> members = opponentByRoom.get(roomId);
                             ChatRoomValidator.validateDirectRoomOpponent(members, roomId);
-                            return members.getFirst().getUserId();
+                            ChatRoomMember member = members.getFirst();
+                            return new OpponentMember(member.getUserId(), member.getRole());
                         }
                 ));
     }
 
-    private Map<Long, User> loadOpponentUsers(Map<Long, Long> roomToOpponentUserIdMap) {
-        Set<Long> opponentUserIds = new HashSet<>(roomToOpponentUserIdMap.values());
+    private Map<Long, User> loadOpponentUsers(Map<Long, OpponentMember> roomToOpponentMemberMap) {
+        Set<Long> opponentUserIds = roomToOpponentMemberMap.values().stream()
+                .map(OpponentMember::userId)
+                .filter(id -> id != null)
+                .collect(Collectors.toCollection(HashSet::new));
         if (opponentUserIds.isEmpty()) {
             return Map.of();
         }
@@ -97,18 +111,50 @@ public class OpponentInfoServiceImpl implements OpponentInfoService {
                 .collect(Collectors.toMap(User::getId, u -> u));
     }
 
-    private OpponentInfo toOpponentInfo(Long opponentUserId, Map<Long, User> userMap) {
-        if (opponentUserId == null) {
+    private Map<Long, Brand> loadOpponentBrands(Map<Long, OpponentMember> roomToOpponentMemberMap) {
+        List<Long> brandUserIds = roomToOpponentMemberMap.values().stream()
+                .filter(member -> member.role() == ChatRoomMemberRole.BRAND)
+                .map(OpponentMember::userId)
+                .filter(id -> id != null)
+                .distinct()
+                .toList();
+        if (brandUserIds.isEmpty()) {
+            return Map.of();
+        }
+        return brandRepository.findByUserIdIn(brandUserIds).stream()
+                .collect(Collectors.toMap(b -> b.getUser().getId(), b -> b));
+    }
+
+    private OpponentInfo toOpponentInfo(
+            OpponentMember opponentMember,
+            Map<Long, User> userMap,
+            Map<Long, Brand> brandMap
+    ) {
+        if (opponentMember == null || opponentMember.userId() == null) {
             return unknownOpponentInfo(null);
         }
-        User user = userMap.get(opponentUserId);
+        User user = userMap.get(opponentMember.userId());
         if (user == null) {
-            return unknownOpponentInfo(opponentUserId);
+            return unknownOpponentInfo(opponentMember.userId());
+        }
+        Brand brand = brandMap.get(opponentMember.userId());
+        return toOpponentInfo(opponentMember.userId(), opponentMember.role(), user, brand);
+    }
+
+    private OpponentInfo toOpponentInfo(Long opponentUserId, ChatRoomMemberRole role, User user, Brand brand) {
+        if (role == ChatRoomMemberRole.BRAND) {
+            String brandName = brand != null ? brand.getBrandName() : ChatConstants.UNKNOWN_OPPONENT_NAME;
+            String brandImageUrl = brand != null ? brand.getLogoUrl() : null;
+            String profileImageUrl = brandImageUrl != null ? brandImageUrl : user.getProfileImageUrl();
+            return new OpponentInfo(opponentUserId, brandName, profileImageUrl);
         }
         return new OpponentInfo(opponentUserId, user.getNickname(), user.getProfileImageUrl());
     }
 
     private OpponentInfo unknownOpponentInfo(Long opponentUserId) {
         return new OpponentInfo(opponentUserId, ChatConstants.UNKNOWN_OPPONENT_NAME, null);
+    }
+
+    private record OpponentMember(Long userId, ChatRoomMemberRole role) {
     }
 }

--- a/src/main/java/com/example/RealMatch/chat/application/service/room/OpponentInfoServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/chat/application/service/room/OpponentInfoServiceImpl.java
@@ -8,13 +8,13 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.example.RealMatch.brand.domain.entity.Brand;
+import com.example.RealMatch.brand.domain.repository.BrandRepository;
 import com.example.RealMatch.chat.application.util.ChatConstants;
 import com.example.RealMatch.chat.application.util.ChatRoomValidator;
 import com.example.RealMatch.chat.code.ChatErrorCode;
 import com.example.RealMatch.chat.domain.entity.ChatRoomMember;
 import com.example.RealMatch.chat.domain.enums.ChatRoomMemberRole;
-import com.example.RealMatch.brand.domain.entity.Brand;
-import com.example.RealMatch.brand.domain.repository.BrandRepository;
 import com.example.RealMatch.chat.domain.repository.ChatRoomMemberRepository;
 import com.example.RealMatch.global.exception.CustomException;
 import com.example.RealMatch.user.domain.entity.User;

--- a/src/main/java/com/example/RealMatch/chat/presentation/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/example/RealMatch/chat/presentation/dto/response/ChatRoomDetailResponse.java
@@ -1,5 +1,7 @@
 package com.example.RealMatch.chat.presentation.dto.response;
 
+import com.example.RealMatch.chat.domain.enums.ChatRoomMemberRole;
+
 public record ChatRoomDetailResponse(
         Long roomId,
         Long opponentUserId,
@@ -7,6 +9,7 @@ public record ChatRoomDetailResponse(
         String opponentProfileImageUrl,
         boolean isCollaborating,  // 협업중 여부
         CampaignSummaryResponse campaignSummary,  // 협업 요약 바 정보 (제안이 있는 경우에만 null이 아님)
-        Long latestProposalId  // 재제안 폼 진입용. 해당 채팅방의 최신 PROPOSAL_CARD/RE_PROPOSAL_CARD 메시지의 proposalId (제안 없으면 null)
+        Long latestProposalId,  // 재제안 폼 진입용. 해당 채팅방의 최신 PROPOSAL_CARD/RE_PROPOSAL_CARD 메시지의 proposalId (제안 없으면 null)
+        ChatRoomMemberRole myRole  // 현재 사용자의 채팅방 내 역할 (BRAND 또는 CREATOR)
 ) {
 }


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
채팅방 상세 응답(`ChatRoomDetailResponse`)에 `myRole` 필드를 추가하여 더 깔끔한 설계로 개선했습니다. 프론트엔드는 채팅방 입장 시 1번만 `myRole`을 받아서 클라이언트 상태로 보관하고, 모든 시스템 메시지 카드 렌더링 시 이를 활용합니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
1. **`ChatRoomDetailResponse`에 `myRole` 필드 추가**
   - 채팅방 상세 조회 시 현재 사용자의 역할(`BRAND` 또는 `CREATOR`)을 함께 반환
   - 추가 쿼리 없이 기존 `getActiveMemberOrThrow` 결과에서 `getRole()`을 추출하여 전달

## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #329 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->