### PR TITLE
fix(#140): 캠페인 정보 조회에 dday, 카테고리 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/campaign/application/service/CampaignQueryService.java
+++ b/src/main/java/com/example/RealMatch/campaign/application/service/CampaignQueryService.java
@@ -1,5 +1,6 @@
 package com.example.RealMatch.campaign.application.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -40,6 +41,7 @@ public class CampaignQueryService {
 
         String imageUrl = attachmentUrlService.getAccessUrl(campaign.getImageUrl());
 
-        return CampaignDetailResponse.from(campaign, imageUrl, isLike, tags);
+        LocalDate today = LocalDate.now();
+        return CampaignDetailResponse.from(campaign, imageUrl, isLike,  today, tags);
     }
 }

--- a/src/main/java/com/example/RealMatch/campaign/application/service/CampaignQueryService.java
+++ b/src/main/java/com/example/RealMatch/campaign/application/service/CampaignQueryService.java
@@ -1,6 +1,7 @@
 package com.example.RealMatch.campaign.application.service;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -41,7 +42,7 @@ public class CampaignQueryService {
 
         String imageUrl = attachmentUrlService.getAccessUrl(campaign.getImageUrl());
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         return CampaignDetailResponse.from(campaign, imageUrl, isLike,  today, tags);
     }
 }

--- a/src/main/java/com/example/RealMatch/campaign/presentation/controller/CampaignController.java
+++ b/src/main/java/com/example/RealMatch/campaign/presentation/controller/CampaignController.java
@@ -31,6 +31,9 @@ public class CampaignController {
             description = """
                     캠페인 상세 정보를 조회합니다.
                     
+                    * dday가 -1인 것은은 dday가 지난 상태를 말합니다.    
+                    * 카테고리는 브랜드의 카테고리를 따라갑니다. (데모데이 이후 캠페인 카테고리로 수정 예정)    
+                    
                     formats : 형식, 
                     categories : 종류, 
                     tones : 톤, 

--- a/src/main/java/com/example/RealMatch/campaign/presentation/controller/CampaignController.java
+++ b/src/main/java/com/example/RealMatch/campaign/presentation/controller/CampaignController.java
@@ -31,8 +31,8 @@ public class CampaignController {
             description = """
                     캠페인 상세 정보를 조회합니다.
                     
-                    * dday가 -1인 것은은 dday가 지난 상태를 말합니다.    
-                    * 카테고리는 브랜드의 카테고리를 따라갑니다. (데모데이 이후 캠페인 카테고리로 수정 예정)    
+                    * dday가 -1인 것은 dday가 지난 상태를 말합니다.    
+                    * 카테고리는 브랜드의 카테고리를 따라갑니다. (데모데이 이후 캠페인 카테고리로 수정 예정)     
                     
                     formats : 형식, 
                     categories : 종류, 

--- a/src/main/java/com/example/RealMatch/campaign/presentation/dto/response/CampaignDetailResponse.java
+++ b/src/main/java/com/example/RealMatch/campaign/presentation/dto/response/CampaignDetailResponse.java
@@ -2,11 +2,13 @@ package com.example.RealMatch.campaign.presentation.dto.response;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import com.example.RealMatch.brand.domain.entity.enums.IndustryType;
 import com.example.RealMatch.campaign.domain.entity.Campaign;
 import com.example.RealMatch.campaign.domain.entity.CampaignContentTag;
 import com.example.RealMatch.tag.domain.enums.ContentTagType;
@@ -19,10 +21,11 @@ import lombok.Getter;
 @Builder
 public class CampaignDetailResponse {
 
-    private Long  campaignId;
+    private Long campaignId;
     private String title;
     private String description;
     private String imageUrl;
+    private IndustryType category;
 
     private String preferredSkills;
     private String schedule;
@@ -42,6 +45,7 @@ public class CampaignDetailResponse {
 
     private LocalDateTime recruitStartDate;
     private LocalDateTime recruitEndDate;
+    private int dday;
 
     private Integer quota;
 
@@ -51,13 +55,19 @@ public class CampaignDetailResponse {
             Campaign campaign,
             String imageUrl,
             boolean isLike,
+            LocalDate today,
             List<CampaignContentTag> tags
     ) {
+        int dday = (int) ChronoUnit.DAYS.between(
+                today, campaign.getRecruitEndDate().toLocalDate()
+        );
+
         return CampaignDetailResponse.builder()
                 .campaignId(campaign.getId())
                 .title(campaign.getTitle())
                 .description(campaign.getDescription())
                 .imageUrl(imageUrl)
+                .category(campaign.getBrand().getIndustryType())
                 .preferredSkills(campaign.getPreferredSkills())
                 .schedule(campaign.getSchedule())
                 .videoSpec(campaign.getVideoSpec())
@@ -68,6 +78,7 @@ public class CampaignDetailResponse {
                 .endDate(campaign.getEndDate())
                 .recruitStartDate(campaign.getRecruitStartDate())
                 .recruitEndDate(campaign.getRecruitEndDate())
+                .dday(Math.max(dday, -1))
                 .quota(campaign.getQuota())
                 .contentTags(toContentTagResponse(tags))
                 .build();


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)
fix(#140): 캠페인 정보 조회에 dday, 카테고리 추가

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
캠페인 상세 정보 조회에 dday, 카테고리 추가


## Changes
- [ ] 캠페인 정보 조회에 dday, 카테고리 추가


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
#140 

## 참고 사항
dday 가 -1인것은 이미 dday가 지난 캠페인을 의미합니다.
캠페인의 카테고리는 현재 브랜드의 카테고리를 따라가고 있습니다. (데모데이 이후 캠페인의 카테고리로 변경 예정)