### PR TITLE
feat(#333): 브랜드 검색 api 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/brand/domain/repository/BrandDescribeTagRepository.java
+++ b/src/main/java/com/example/RealMatch/brand/domain/repository/BrandDescribeTagRepository.java
@@ -11,4 +11,6 @@ import com.example.RealMatch.brand.domain.entity.BrandDescribeTag;
 public interface BrandDescribeTagRepository extends JpaRepository<BrandDescribeTag, Long> {
 
     List<BrandDescribeTag> findAllByBrandId(Long brandId);
+
+    List<BrandDescribeTag> findAllByBrandIdIn(List<Long> brandIds);
 }

--- a/src/main/java/com/example/RealMatch/brand/presentation/controller/BrandController.java
+++ b/src/main/java/com/example/RealMatch/brand/presentation/controller/BrandController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.RealMatch.brand.application.service.BrandService;
@@ -34,6 +35,10 @@ import com.example.RealMatch.brand.presentation.swagger.BrandSwagger;
 import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
 import com.example.RealMatch.global.presentation.code.GeneralSuccessCode;
+import com.example.RealMatch.match.application.service.MatchService;
+import com.example.RealMatch.match.domain.entity.enums.BrandSortType;
+import com.example.RealMatch.match.domain.entity.enums.CategoryType;
+import com.example.RealMatch.match.presentation.dto.response.MatchBrandResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,6 +48,7 @@ import lombok.RequiredArgsConstructor;
 public class BrandController implements BrandSwagger {
 
     private final BrandService brandService;
+    private final MatchService matchService;
 
     // ******** //
     // 브랜드 조회 //
@@ -56,6 +62,21 @@ public class BrandController implements BrandSwagger {
         Long currentUserId = principal.getUserId();
         BrandDetailResponseDto result = brandService.getBrandDetail(brandId, currentUserId);
         return CustomResponse.onSuccess(GeneralSuccessCode.GOOD_REQUEST, Collections.singletonList(result));
+    }
+
+    @Override
+    @GetMapping("/search")
+    public CustomResponse<MatchBrandResponseDto> searchBrands(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String title,
+            @RequestParam(defaultValue = "MATCH_SCORE") BrandSortType sortBy,
+            @RequestParam(defaultValue = "ALL") CategoryType category,
+            @RequestParam(required = false) List<String> tags,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        String userId = String.valueOf(userDetails.getUserId());
+        MatchBrandResponseDto result = matchService.searchMatchingBrands(userId, title, sortBy, category, tags, page, size);
+        return CustomResponse.ok(result);
     }
 
     @Override

--- a/src/main/java/com/example/RealMatch/brand/presentation/swagger/BrandSwagger.java
+++ b/src/main/java/com/example/RealMatch/brand/presentation/swagger/BrandSwagger.java
@@ -23,6 +23,9 @@ import com.example.RealMatch.brand.presentation.dto.response.SponsorProductDetai
 import com.example.RealMatch.brand.presentation.dto.response.SponsorProductListResponseDto;
 import com.example.RealMatch.global.config.jwt.CustomUserDetails;
 import com.example.RealMatch.global.presentation.CustomResponse;
+import com.example.RealMatch.match.domain.entity.enums.BrandSortType;
+import com.example.RealMatch.match.domain.entity.enums.CategoryType;
+import com.example.RealMatch.match.presentation.dto.response.MatchBrandResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -86,6 +89,28 @@ public interface BrandSwagger {
     CustomResponse<java.util.List<BrandDetailResponseDto>> getBrandDetail(
             @Parameter(description = "조회할 브랜드의 ID", required = true) @PathVariable Long brandId,
             @Parameter(hidden = true) CustomUserDetails principal
+    );
+
+    @Operation(summary = "브랜드 검색 by 이예림",
+            description = """
+                    JWT 토큰의 사용자 ID를 기반으로 매칭률이 높은 브랜드 목록을 검색합니다.
+                    **검색**: title을 입력하면 브랜드명(title)만 검색합니다.
+                    정렬 옵션: MATCH_SCORE(매칭률 순), POPULARITY(인기순), NEWEST(신규순)
+                    카테고리 필터: ALL(전체), FASHION(패션), BEAUTY(뷰티)
+                    태그 필터: 뷰티/패션 관련 태그로 필터링
+                    페이지네이션: page(0부터 시작), size(기본 20)
+                    """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "브랜드 검색 성공")
+    })
+    CustomResponse<MatchBrandResponseDto> searchBrands(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "브랜드명 검색어 (브랜드명 title만 검색)") String title,
+            @Parameter(description = "정렬 기준 (MATCH_SCORE, POPULARITY, NEWEST)") BrandSortType sortBy,
+            @Parameter(description = "카테고리 필터 (ALL, FASHION, BEAUTY)") CategoryType category,
+            @Parameter(description = "태그 필터 (예: 스킨케어, 미니멀)") List<String> tags,
+            @Parameter(description = "페이지 번호 (0부터 시작)") int page,
+            @Parameter(description = "페이지 크기 (기본 20)") int size
     );
 
     @Operation(summary = "브랜드 좋아요 토글 by 이예림", description = "브랜드 ID로 좋아요를 추가하거나 취소합니다.")
@@ -177,7 +202,7 @@ public interface BrandSwagger {
             @Parameter(description = "조회할 유저의 ID", required = true) @PathVariable Long userId
     );
 
-    @Operation(summary = "브랜드 개별 요약 조회 API", description = "사진 클릭 시 하단에 노출되는 브랜드의 기본 정보(이미지, 이름, 태그, 매칭률)를 조회합니다.")
+    @Operation(summary = "브랜드 개별 요약 조회 API by 이예림", description = "사진 클릭 시 하단에 노출되는 브랜드의 기본 정보(이미지, 이름, 태그, 매칭률)를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = BrandSimpleDetailResponse.class))),

--- a/src/main/java/com/example/RealMatch/match/application/service/MatchService.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchService.java
@@ -16,6 +16,16 @@ public interface MatchService {
 
     MatchBrandResponseDto getMatchingBrands(String userId, BrandSortType sortBy, CategoryType category, List<String> tags);
 
+    MatchBrandResponseDto searchMatchingBrands(
+            String userId,
+            String title,
+            BrandSortType sortBy,
+            CategoryType category,
+            List<String> tags,
+            int page,
+            int size
+    );
+
     MatchCampaignResponseDto getMatchingCampaigns(
             String userId,
             String keyword,

--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -474,12 +474,10 @@ public class MatchServiceImpl implements MatchService {
         List<Long> brandIds = brandHistories.stream()
                 .map(h -> h.getBrand().getId())
                 .toList();
-        Map<Long, List<String>> brandDescribeTagMap = brandIds.stream()
-                .collect(Collectors.toMap(
-                        brandId -> brandId,
-                        brandId -> brandDescribeTagRepository.findAllByBrandId(brandId).stream()
-                                .map(BrandDescribeTag::getBrandDescribeTag)
-                                .toList()
+        Map<Long, List<String>> brandDescribeTagMap = brandDescribeTagRepository.findAllByBrandIdIn(brandIds).stream()
+                .collect(Collectors.groupingBy(
+                        tag -> tag.getBrand().getId(),
+                        Collectors.mapping(BrandDescribeTag::getBrandDescribeTag, Collectors.toList())
                 ));
 
         List<MatchBrandResponseDto.BrandDto> matchedBrands = brandHistories.stream()
@@ -529,12 +527,10 @@ public class MatchServiceImpl implements MatchService {
         List<Long> brandIds = brandHistories.stream()
                 .map(h -> h.getBrand().getId())
                 .toList();
-        Map<Long, List<String>> brandDescribeTagMap = brandIds.stream()
-                .collect(Collectors.toMap(
-                        brandId -> brandId,
-                        brandId -> brandDescribeTagRepository.findAllByBrandId(brandId).stream()
-                                .map(BrandDescribeTag::getBrandDescribeTag)
-                                .toList()
+        Map<Long, List<String>> brandDescribeTagMap = brandDescribeTagRepository.findAllByBrandIdIn(brandIds).stream()
+                .collect(Collectors.groupingBy(
+                        tag -> tag.getBrand().getId(),
+                        Collectors.mapping(BrandDescribeTag::getBrandDescribeTag, Collectors.toList())
                 ));
 
         List<MatchBrandResponseDto.BrandDto> filteredBrands = brandHistories.stream()

--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -506,9 +507,14 @@ public class MatchServiceImpl implements MatchService {
     ) {
         Long userIdLong = Long.parseLong(userId);
 
-        List<MatchBrandHistory> brandHistories = matchBrandHistoryRepository.findByUserIdAndIsDeprecatedFalse(userIdLong);
+        int safePage = Math.max(page, 0);
+        int safeSize = size <= 0 ? 20 : size;
+        PageRequest pageable = PageRequest.of(safePage, safeSize);
 
-        if (brandHistories.isEmpty()) {
+        Page<MatchBrandHistory> historyPage = matchBrandHistoryRepository
+                .searchBrands(userIdLong, title, category, sortBy, tags, pageable);
+
+        if (historyPage.isEmpty()) {
             LOG.warn("No match brand history found in DB. userId={}", userId);
             return MatchBrandResponseDto.builder()
                     .count(0)
@@ -521,36 +527,22 @@ public class MatchServiceImpl implements MatchService {
                 .collect(Collectors.toSet());
 
         Set<Long> recruitingBrandIds = getRecruitingBrandIds();
-        Map<Long, Long> brandLikeCountMap = getBrandLikeCountMap();
 
-        // BrandDescribeTag 조회하여 Map으로 변환
-        List<Long> brandIds = brandHistories.stream()
+        List<Long> pageBrandIds = historyPage.getContent().stream()
                 .map(h -> h.getBrand().getId())
                 .toList();
-        Map<Long, List<String>> brandDescribeTagMap = brandDescribeTagRepository.findAllByBrandIdIn(brandIds).stream()
+        Map<Long, List<String>> brandDescribeTagMap = brandDescribeTagRepository.findAllByBrandIdIn(pageBrandIds).stream()
                 .collect(Collectors.groupingBy(
                         tag -> tag.getBrand().getId(),
                         Collectors.mapping(BrandDescribeTag::getBrandDescribeTag, Collectors.toList())
                 ));
 
-        List<MatchBrandResponseDto.BrandDto> filteredBrands = brandHistories.stream()
-                .filter(history -> filterBrandByCategory(history.getBrand(), category))
-                .filter(history -> filterBrandByTitle(history.getBrand(), title))
-                .filter(history -> filterBrandByTags(history.getBrand().getId(), tags, brandDescribeTagMap))
-                .sorted(getBrandHistoryComparator(sortBy, brandLikeCountMap))
+        List<MatchBrandResponseDto.BrandDto> pagedBrands = historyPage.getContent().stream()
                 .map(history -> toMatchBrandDtoFromHistory(history, likedBrandIds, recruitingBrandIds, brandDescribeTagMap))
                 .toList();
 
-        int total = filteredBrands.size();
-        int safePage = Math.max(page, 0);
-        int safeSize = size <= 0 ? 20 : size;
-        int fromIndex = safePage * safeSize;
-        int toIndex = Math.min(fromIndex + safeSize, total);
-        List<MatchBrandResponseDto.BrandDto> pagedBrands =
-                fromIndex >= total ? List.of() : filteredBrands.subList(fromIndex, toIndex);
-
         return MatchBrandResponseDto.builder()
-                .count(total)
+                .count((int) historyPage.getTotalElements())
                 .brands(pagedBrands)
                 .build();
     }

--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.example.RealMatch.brand.domain.entity.Brand;
 import com.example.RealMatch.brand.domain.entity.BrandDescribeTag;
@@ -483,6 +484,7 @@ public class MatchServiceImpl implements MatchService {
 
         List<MatchBrandResponseDto.BrandDto> matchedBrands = brandHistories.stream()
                 .filter(history -> filterBrandByCategory(history.getBrand(), category))
+                .filter(history -> filterBrandByTags(history.getBrand().getId(), tags, brandDescribeTagMap))
                 .sorted(getBrandHistoryComparator(sortBy, brandLikeCountMap))
                 .limit(TOP_MATCH_COUNT)
                 .map(history -> toMatchBrandDtoFromHistory(history, likedBrandIds, recruitingBrandIds, brandDescribeTagMap))
@@ -491,6 +493,69 @@ public class MatchServiceImpl implements MatchService {
         return MatchBrandResponseDto.builder()
                 .count(matchedBrands.size())
                 .brands(matchedBrands)
+                .build();
+    }
+
+    @Override
+    public MatchBrandResponseDto searchMatchingBrands(
+            String userId,
+            String title,
+            BrandSortType sortBy,
+            CategoryType category,
+            List<String> tags,
+            int page,
+            int size
+    ) {
+        Long userIdLong = Long.parseLong(userId);
+
+        List<MatchBrandHistory> brandHistories = matchBrandHistoryRepository.findByUserIdAndIsDeprecatedFalse(userIdLong);
+
+        if (brandHistories.isEmpty()) {
+            LOG.warn("No match brand history found in DB. userId={}", userId);
+            return MatchBrandResponseDto.builder()
+                    .count(0)
+                    .brands(List.of())
+                    .build();
+        }
+
+        Set<Long> likedBrandIds = brandLikeRepository.findByUserId(userIdLong).stream()
+                .map(like -> like.getBrand().getId())
+                .collect(Collectors.toSet());
+
+        Set<Long> recruitingBrandIds = getRecruitingBrandIds();
+        Map<Long, Long> brandLikeCountMap = getBrandLikeCountMap();
+
+        // BrandDescribeTag 조회하여 Map으로 변환
+        List<Long> brandIds = brandHistories.stream()
+                .map(h -> h.getBrand().getId())
+                .toList();
+        Map<Long, List<String>> brandDescribeTagMap = brandIds.stream()
+                .collect(Collectors.toMap(
+                        brandId -> brandId,
+                        brandId -> brandDescribeTagRepository.findAllByBrandId(brandId).stream()
+                                .map(BrandDescribeTag::getBrandDescribeTag)
+                                .toList()
+                ));
+
+        List<MatchBrandResponseDto.BrandDto> filteredBrands = brandHistories.stream()
+                .filter(history -> filterBrandByCategory(history.getBrand(), category))
+                .filter(history -> filterBrandByTitle(history.getBrand(), title))
+                .filter(history -> filterBrandByTags(history.getBrand().getId(), tags, brandDescribeTagMap))
+                .sorted(getBrandHistoryComparator(sortBy, brandLikeCountMap))
+                .map(history -> toMatchBrandDtoFromHistory(history, likedBrandIds, recruitingBrandIds, brandDescribeTagMap))
+                .toList();
+
+        int total = filteredBrands.size();
+        int safePage = Math.max(page, 0);
+        int safeSize = size <= 0 ? 20 : size;
+        int fromIndex = safePage * safeSize;
+        int toIndex = Math.min(fromIndex + safeSize, total);
+        List<MatchBrandResponseDto.BrandDto> pagedBrands =
+                fromIndex >= total ? List.of() : filteredBrands.subList(fromIndex, toIndex);
+
+        return MatchBrandResponseDto.builder()
+                .count(total)
+                .brands(pagedBrands)
                 .build();
     }
 
@@ -605,6 +670,37 @@ public class MatchServiceImpl implements MatchService {
                     (MatchBrandHistory h) -> h.getMatchingRatio() != null ? h.getMatchingRatio() : 0L
             ).reversed();
         };
+    }
+
+    private boolean filterBrandByTitle(Brand brand, String title) {
+        if (!StringUtils.hasText(title)) {
+            return true;
+        }
+        String brandName = brand != null ? brand.getBrandName() : null;
+        if (!StringUtils.hasText(brandName)) {
+            return false;
+        }
+        return brandName.toLowerCase().contains(title.trim().toLowerCase());
+    }
+
+    private boolean filterBrandByTags(Long brandId, List<String> tags, Map<Long, List<String>> brandDescribeTagMap) {
+        if (tags == null || tags.isEmpty()) {
+            return true;
+        }
+        List<String> brandTags = brandDescribeTagMap.getOrDefault(brandId, List.of());
+        if (brandTags.isEmpty()) {
+            return false;
+        }
+
+        List<String> normalizedBrandTags = brandTags.stream()
+                .filter(StringUtils::hasText)
+                .map(tag -> tag.trim().toLowerCase())
+                .toList();
+
+        return tags.stream()
+                .filter(StringUtils::hasText)
+                .map(tag -> tag.trim().toLowerCase())
+                .anyMatch(normalizedBrandTags::contains);
     }
 
     private MatchBrandResponseDto.BrandDto toMatchBrandDtoFromHistory(

--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.example.RealMatch.match.domain.entity.MatchBrandHistory;
 
-public interface MatchBrandHistoryRepository extends JpaRepository<MatchBrandHistory, Long> {
+public interface MatchBrandHistoryRepository extends JpaRepository<MatchBrandHistory, Long>, MatchBrandHistoryRepositoryCustom {
 
     List<MatchBrandHistory> findByUserId(Long userId);
 

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepositoryCustom.java
@@ -1,0 +1,29 @@
+package com.example.RealMatch.match.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.example.RealMatch.match.domain.entity.MatchBrandHistory;
+import com.example.RealMatch.match.domain.entity.enums.BrandSortType;
+import com.example.RealMatch.match.domain.entity.enums.CategoryType;
+
+public interface MatchBrandHistoryRepositoryCustom {
+
+    Page<MatchBrandHistory> searchBrands(
+            Long userId,
+            String title,
+            CategoryType category,
+            BrandSortType sortBy,
+            List<String> tags,
+            Pageable pageable
+    );
+
+    long countSearchBrands(
+            Long userId,
+            String title,
+            CategoryType category,
+            List<String> tags
+    );
+}

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepositoryCustomImpl.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepositoryCustomImpl.java
@@ -1,7 +1,6 @@
 package com.example.RealMatch.match.domain.repository;
 
 import static com.example.RealMatch.brand.domain.entity.QBrand.brand;
-import static com.example.RealMatch.brand.domain.entity.QBrandDescribeTag.brandDescribeTag;
 import static com.example.RealMatch.match.domain.entity.QMatchBrandHistory.matchBrandHistory;
 
 import java.util.List;
@@ -12,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import com.example.RealMatch.brand.domain.entity.QBrandDescribeTag;
 import com.example.RealMatch.brand.domain.entity.QBrandLike;
 import com.example.RealMatch.match.domain.entity.MatchBrandHistory;
 import com.example.RealMatch.match.domain.entity.enums.BrandSortType;
@@ -28,6 +28,8 @@ import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
 public class MatchBrandHistoryRepositoryCustomImpl implements MatchBrandHistoryRepositoryCustom {
+
+    private static final QBrandDescribeTag BRAND_DESCRIBE_TAG = QBrandDescribeTag.brandDescribeTag1;
 
     private final JPAQueryFactory queryFactory;
 
@@ -95,13 +97,13 @@ public class MatchBrandHistoryRepositoryCustomImpl implements MatchBrandHistoryR
                     .toList();
 
             if (!normalizedTags.isEmpty()) {
-                StringExpression tagLower = brandDescribeTag.brandDescribeTag.lower();
+                StringExpression tagLower = BRAND_DESCRIBE_TAG.brandDescribeTag.lower();
                 builder.and(
                         JPAExpressions
                                 .selectOne()
-                                .from(brandDescribeTag)
+                                .from(BRAND_DESCRIBE_TAG)
                                 .where(
-                                        brandDescribeTag.brand.id.eq(brand.id),
+                                        BRAND_DESCRIBE_TAG.brand.id.eq(brand.id),
                                         tagLower.in(normalizedTags)
                                 )
                                 .exists()

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepositoryCustomImpl.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepositoryCustomImpl.java
@@ -1,0 +1,145 @@
+package com.example.RealMatch.match.domain.repository;
+
+import static com.example.RealMatch.brand.domain.entity.QBrand.brand;
+import static com.example.RealMatch.brand.domain.entity.QBrandDescribeTag.brandDescribeTag;
+import static com.example.RealMatch.match.domain.entity.QMatchBrandHistory.matchBrandHistory;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import com.example.RealMatch.brand.domain.entity.QBrandLike;
+import com.example.RealMatch.match.domain.entity.MatchBrandHistory;
+import com.example.RealMatch.match.domain.entity.enums.BrandSortType;
+import com.example.RealMatch.match.domain.entity.enums.CategoryType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchBrandHistoryRepositoryCustomImpl implements MatchBrandHistoryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MatchBrandHistory> searchBrands(
+            Long userId,
+            String title,
+            CategoryType category,
+            BrandSortType sortBy,
+            List<String> tags,
+            Pageable pageable
+    ) {
+        BooleanBuilder whereClause = buildWhereClause(userId, title, category, tags);
+        List<OrderSpecifier<?>> orderSpecifiers = buildOrderSpecifiers(sortBy);
+
+        List<MatchBrandHistory> content = queryFactory
+                .selectFrom(matchBrandHistory)
+                .join(matchBrandHistory.brand, brand).fetchJoin()
+                .where(whereClause)
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier<?>[0]))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = countSearchBrands(userId, title, category, tags);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public long countSearchBrands(Long userId, String title, CategoryType category, List<String> tags) {
+        BooleanBuilder whereClause = buildWhereClause(userId, title, category, tags);
+
+        Long count = queryFactory
+                .select(matchBrandHistory.count())
+                .from(matchBrandHistory)
+                .join(matchBrandHistory.brand, brand)
+                .where(whereClause)
+                .fetchOne();
+
+        return count != null ? count : 0L;
+    }
+
+    // *********** //
+    // 검색 조건 빌더 //
+    // *********** //
+    private BooleanBuilder buildWhereClause(Long userId, String title, CategoryType category, List<String> tags) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(matchBrandHistory.user.id.eq(userId));
+        builder.and(matchBrandHistory.isDeprecated.eq(false));
+
+        if (StringUtils.hasText(title)) {
+            builder.and(brand.brandName.containsIgnoreCase(title.trim()));
+        }
+
+        if (category != null && category != CategoryType.ALL) {
+            builder.and(brand.industryType.stringValue().equalsIgnoreCase(category.name()));
+        }
+
+        if (tags != null && !tags.isEmpty()) {
+            List<String> normalizedTags = tags.stream()
+                    .filter(StringUtils::hasText)
+                    .map(tag -> tag.trim().toLowerCase())
+                    .toList();
+
+            if (!normalizedTags.isEmpty()) {
+                StringExpression tagLower = brandDescribeTag.brandDescribeTag.lower();
+                builder.and(
+                        JPAExpressions
+                                .selectOne()
+                                .from(brandDescribeTag)
+                                .where(
+                                        brandDescribeTag.brand.id.eq(brand.id),
+                                        tagLower.in(normalizedTags)
+                                )
+                                .exists()
+                );
+            }
+        }
+
+        return builder;
+    }
+
+    // *********** //
+    // 정렬 조건 빌더 //
+    // *********** //
+    private com.querydsl.core.types.Expression<Long> likeCountSubquery() {
+        QBrandLike likeSub = new QBrandLike("bl");
+        return JPAExpressions
+                .select(likeSub.id.count())
+                .from(likeSub)
+                .where(likeSub.brand.id.eq(brand.id));
+    }
+
+    private OrderSpecifier<?> likeCountDesc() {
+        return new OrderSpecifier<>(Order.DESC, likeCountSubquery(), OrderSpecifier.NullHandling.NullsLast);
+    }
+
+    private List<OrderSpecifier<?>> buildOrderSpecifiers(BrandSortType sortBy) {
+        if (sortBy == null) {
+            sortBy = BrandSortType.MATCH_SCORE;
+        }
+
+        OrderSpecifier<?> matchingRatioDesc = matchBrandHistory.matchingRatio.desc().nullsLast();
+        OrderSpecifier<?> brandIdDesc = brand.id.desc();
+        OrderSpecifier<?> popularityDesc = likeCountDesc();
+
+        return switch (sortBy) {
+            case POPULARITY -> List.of(popularityDesc, matchingRatioDesc, brandIdDesc);
+            case NEWEST -> List.of(brandIdDesc);
+            default -> List.of(matchingRatioDesc, popularityDesc, brandIdDesc);
+        };
+    }
+}


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
/api/v1/brands/search 엔드포인트를 추가해 매칭된 브랜드를 브랜드명(title)로 검색할 수 있게 했고, sortBy, category, tags 필터를 동일하게 적용했습니다. 검색 결과는 페이지네이션(page, size)을 지원합니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- /api/v1/brands/search API 신규 추가
- 브랜드명(title) 검색 로직 추가 (브랜드명만 대상)
- sortBy, category, tags 필터 동일 적용
- TOP 10 제한 제거 및 페이지네이션 적용
- Swagger 문서 업데이트

## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #333 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->