### PR TITLE
[REFACTOR] 콘텐츠 형식 (카테고리) 추가 (#350)

### DIFF
--- a/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
+++ b/src/main/java/com/example/RealMatch/match/application/service/MatchServiceImpl.java
@@ -278,6 +278,9 @@ public class MatchServiceImpl implements MatchService {
             if (dto.getContent().getTypeTags() != null) {
                 contentTags.addAll(dto.getContent().getTypeTags());
             }
+            if (dto.getContent().getCategoryTags() != null) {
+                contentTags.addAll(dto.getContent().getCategoryTags());
+            }
             if (dto.getContent().getToneTags() != null) {
                 contentTags.addAll(dto.getContent().getToneTags());
             }
@@ -706,6 +709,7 @@ public class MatchServiceImpl implements MatchService {
 
         if (dto.getContent() != null) {
             addAll(tagIds, dto.getContent().getTypeTags());
+            addAll(tagIds, dto.getContent().getCategoryTags());
             addAll(tagIds, dto.getContent().getToneTags());
             addAll(tagIds, dto.getContent().getPrefferedInvolvementTags());
             addAll(tagIds, dto.getContent().getPrefferedCoverageTags());

--- a/src/main/java/com/example/RealMatch/match/presentation/dto/request/MatchRequestDto.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/dto/request/MatchRequestDto.java
@@ -59,6 +59,7 @@ public class MatchRequestDto {
     public static class ContentDto {
         private SnsDto sns;
         private List<Integer> typeTags;
+        private List<Integer> categoryTags;
         private List<Integer> toneTags;
         private List<Integer> prefferedInvolvementTags;
         private List<Integer> prefferedCoverageTags;

--- a/src/main/java/com/example/RealMatch/match/presentation/swagger/MatchSwagger.java
+++ b/src/main/java/com/example/RealMatch/match/presentation/swagger/MatchSwagger.java
@@ -54,35 +54,36 @@ public interface MatchSwagger {
                                                       "beauty": {
                                                         "interestStyleTags": [1, 2],
                                                         "prefferedFunctionTags": [6, 7],
-                                                        "skinTypeTags": 12,
-                                                        "skinToneTags": 13,
-                                                        "makeupStyleTags": 2
+                                                        "skinTypeTags": 11,
+                                                        "skinToneTags": 14,
+                                                        "makeupStyleTags": 19
                                                       },
                                                       "fashion": {
-                                                        "interestStyleTags": [16, 17],
-                                                        "preferredItemTags": [22, 23],
-                                                        "preferredBrandTags": [27, 28],
+                                                        "interestStyleTags": [24, 25],
+                                                        "preferredItemTags": [28, 29],
+                                                        "preferredBrandTags": [33, 24],
                                                         "heightTag": 72,
-                                                        "weightTypeTag": 94,
-                                                        "topSizeTag": 108,
-                                                        "bottomSizeTag": 178
+                                                        "weightTypeTag": 101,
+                                                        "topSizeTag": 104,
+                                                        "bottomSizeTag": 123
                                                       },
                                                       "content": {
                                                         "sns": {
                                                           "url": "https://www.instagram.com/vivi",
                                                           "mainAudience": {
-                                                            "genderTags": [221, 222],
-                                                            "ageTags": [223, 224]
+                                                            "genderTags": [156],
+                                                            "ageTags": [161]
                                                           },
                                                           "averageAudience": {
-                                                            "videoLengthTags": [228, 229],
-                                                            "videoViewsTags": [232, 233]
+                                                            "videoLengthTags": [164, 165],
+                                                            "videoViewsTags": [168, 169]
                                                           }
                                                         },
-                                                        "typeTags": [236, 237],
-                                                        "toneTags": [245, 246],
-                                                        "prefferedInvolvementTags": [251, 252],
-                                                        "prefferedCoverageTags": [255, 256]
+                                                        "typeTags": [171, 172],
+                                                        "categoryTags": [178],
+                                                        "toneTags": [181, 182],
+                                                        "prefferedInvolvementTags": [188, 189],
+                                                        "prefferedCoverageTags": [190, 191]
                                                       }
                                                     }
                                                     """

--- a/src/main/java/com/example/RealMatch/user/application/service/UserFeatureService.java
+++ b/src/main/java/com/example/RealMatch/user/application/service/UserFeatureService.java
@@ -73,6 +73,7 @@ public class UserFeatureService {
                 get(grouped, TagType.CONTENT.getDescription(), ContentTagType.AVG_VIDEO_LENGTH.getKorName()),
                 get(grouped, TagType.CONTENT.getDescription(), ContentTagType.AVG_VIDEO_VIEWS.getKorName()),
                 get(grouped, TagType.CONTENT.getDescription(), ContentTagType.FORMAT.getKorName()),
+                get(grouped, TagType.CONTENT.getDescription(), ContentTagType.CATEGORY.getKorName()),
                 get(grouped, TagType.CONTENT.getDescription(), ContentTagType.TONE.getKorName()),
                 get(grouped, TagType.CONTENT.getDescription(), ContentTagType.INVOLVEMENT.getKorName()),
                 get(grouped, TagType.CONTENT.getDescription(), ContentTagType.USAGE_RANGE.getKorName())
@@ -150,6 +151,7 @@ public class UserFeatureService {
         List<Integer> videoLengthTags = new ArrayList<>();
         List<Integer> videoViewsTags = new ArrayList<>();
         List<Integer> typeTags = new ArrayList<>();
+        List<Integer> categoryTags = new ArrayList<>();
         List<Integer> toneTags = new ArrayList<>();
         List<Integer> preferredInvolvementTags = new ArrayList<>();
         List<Integer> preferredCoverageTags = new ArrayList<>();
@@ -213,6 +215,8 @@ public class UserFeatureService {
                         videoViewsTags.add(tagId);
                     } else if (ContentTagType.FORMAT.getKorName().equals(category)) {
                         typeTags.add(tagId);
+                    } else if (ContentTagType.CATEGORY.getKorName().equals(category)) {
+                        categoryTags.add(tagId);
                     } else if (ContentTagType.TONE.getKorName().equals(category)) {
                         toneTags.add(tagId);
                     } else if (ContentTagType.INVOLVEMENT.getKorName().equals(category)) {
@@ -264,6 +268,7 @@ public class UserFeatureService {
                 .content(MatchRequestDto.ContentDto.builder()
                         .sns(sns)
                         .typeTags(typeTags.isEmpty() ? null : typeTags)
+                        .categoryTags(categoryTags.isEmpty() ? null : categoryTags)
                         .toneTags(toneTags.isEmpty() ? null : toneTags)
                         .prefferedInvolvementTags(preferredInvolvementTags.isEmpty() ? null : preferredInvolvementTags)
                         .prefferedCoverageTags(preferredCoverageTags.isEmpty() ? null : preferredCoverageTags)
@@ -337,6 +342,7 @@ public class UserFeatureService {
         return MatchRequestDto.ContentDto.builder()
                 .sns(mergeSns(cur.getSns(), p.getSns()))
                 .typeTags(p.getTypeTags() != null ? p.getTypeTags() : cur.getTypeTags())
+                .categoryTags(p.getCategoryTags() != null ? p.getCategoryTags() : cur.getCategoryTags())
                 .toneTags(p.getToneTags() != null ? p.getToneTags() : cur.getToneTags())
                 .prefferedInvolvementTags(p.getPrefferedInvolvementTags() != null ? p.getPrefferedInvolvementTags() : cur.getPrefferedInvolvementTags())
                 .prefferedCoverageTags(p.getPrefferedCoverageTags() != null ? p.getPrefferedCoverageTags() : cur.getPrefferedCoverageTags())

--- a/src/main/java/com/example/RealMatch/user/presentation/dto/response/MyFeatureResponseDto.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/dto/response/MyFeatureResponseDto.java
@@ -31,6 +31,7 @@ public record MyFeatureResponseDto(
             List<Integer> avgVideoLength,
             List<Integer> avgViews,
             List<Integer> contentFormats,
+            List<Integer> contentCategories,
             List<Integer> contentTones,
             List<Integer> desiredInvolvement,
             List<Integer> desiredUsageScope


### PR DESCRIPTION
## Summary
매칭 요청(RequestBody)에서 content.categoryTags가 Swagger 예시에서 누락되어
요청 시 값이 전달되지 않던 문제를 수정했습니다.

Swagger 예시 JSON을 실제 MatchRequestDto 구조와 동기화하여,
카테고리 태그가 정상적으로 저장·조회되도록 개선했습니다.


## Changes
- MatchSwagger의 매칭 요청 example JSON에 content.categoryTags 추가
- Swagger 문서와 MatchRequestDto 구조 불일치 문제 해결
- 콘텐츠 카테고리 태그(categoryTags)가 매칭 요청 → 저장 → 조회까지 정상 반영되도록 수정


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
Fixes #350 

## 참고 사항
- 서버 로직 및 DTO는 변경되지 않았으며, Swagger RequestBody example만 수정되었습니다.
- Swagger UI를 통해 매칭 요청 시 categoryTags가 누락되지 않도록 개선되었습니다.