### PR TITLE
[FEAT] 탈퇴 유저 예외처리 구현 (#353)

### DIFF
--- a/src/main/java/com/example/RealMatch/oauth/code/OAuthErrorCode.java
+++ b/src/main/java/com/example/RealMatch/oauth/code/OAuthErrorCode.java
@@ -101,6 +101,12 @@ public enum OAuthErrorCode implements BaseErrorCode {
             "콘텐츠 카테고리를 찾을 수 없습니다."
     ),
 
+    WITHDRAWN_USER(
+            HttpStatus.FORBIDDEN,
+            "AUTH403_1",
+            "탈퇴한 회원입니다."
+    ),
+
     DUPLICATE_NICKNAME(
             HttpStatus.CONFLICT,
             "AUTH409_1",

--- a/src/main/java/com/example/RealMatch/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/RealMatch/oauth/service/CustomOAuth2UserService.java
@@ -60,7 +60,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         // 탈퇴한 유저인지 확인
         User user = authMethod.getUser();
-        if (user.getRole() == Role.WITHDRAWN || user.isDeleted()) {
+        if (user.getRole() == Role.WITHDRAWN) {
             throw new CustomException(OAuthErrorCode.WITHDRAWN_USER);
         }
 

--- a/src/main/java/com/example/RealMatch/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/RealMatch/oauth/service/CustomOAuth2UserService.java
@@ -58,6 +58,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         )
                         .orElseGet(() -> registerNewUser(userInfo));
 
+        // 탈퇴한 유저인지 확인
+        User user = authMethod.getUser();
+        if (user.getRole() == Role.WITHDRAWN || user.isDeleted()) {
+            throw new CustomException(OAuthErrorCode.WITHDRAWN_USER);
+        }
+
         return new CustomOAuth2User(
                 authMethod.getUser().getId(),
                 authMethod.getUser().getRole().name(),


### PR DESCRIPTION
## Summary
탈퇴한 유저는 토큰이 발급 안되게 설정 


## Changes
OAuthErrorCode, CustomOAuth2UserService의 loadUser 메서드


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->