### PR TITLE
[FIX] 이미지 url 사이즈 제거 (#358)

### DIFF
--- a/src/main/java/com/example/RealMatch/user/presentation/dto/request/MyProfileCardUpdateRequestDto.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/dto/request/MyProfileCardUpdateRequestDto.java
@@ -1,6 +1,5 @@
 package com.example.RealMatch.user.presentation.dto.request;
 
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +8,5 @@ import lombok.NoArgsConstructor;
 public class MyProfileCardUpdateRequestDto {
 
     @jakarta.validation.constraints.NotBlank
-    @Size(max = 255)
     private String profileImageUrl;
 }


### PR DESCRIPTION
## Summary
프로필 카드 수정 API에서 profileImageUrl의 불필요한 길이 제한을 제거했습니다.


## Changes
profileImageUrl 필드의 @Size(max = 255) 검증 제거

URL 문자열 길이 초과로 인한 프로필 이미지 수정 실패 문제 해결


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
Fixes #358

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->