### PR TITLE
[FEAT] 유저 즉시 삭제 API 구현 (#365)

### DIFF
--- a/src/main/java/com/example/RealMatch/brand/domain/repository/BrandLikeRepository.java
+++ b/src/main/java/com/example/RealMatch/brand/domain/repository/BrandLikeRepository.java
@@ -24,4 +24,6 @@ public interface BrandLikeRepository extends JpaRepository<BrandLike, Long> {
     void deleteByUserIdAndBrandId(Long userId, Long brandId);
 
     long countByBrandId(Long brandId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/brand/domain/repository/BrandRepository.java
+++ b/src/main/java/com/example/RealMatch/brand/domain/repository/BrandRepository.java
@@ -45,4 +45,6 @@ public interface BrandRepository extends JpaRepository<Brand, Long> {
         where b.brandName like %:keyword%
     """)
     List<Long> findIdsByBrandNameContaining(@Param("keyword") String keyword);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/business/domain/repository/CampaignApplyRepository.java
+++ b/src/main/java/com/example/RealMatch/business/domain/repository/CampaignApplyRepository.java
@@ -81,5 +81,5 @@ public interface CampaignApplyRepository extends JpaRepository<CampaignApply, Lo
             @Param("brandIds") List<Long> brandIds
     );
 
-
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/business/domain/repository/CampaignProposalRepository.java
+++ b/src/main/java/com/example/RealMatch/business/domain/repository/CampaignProposalRepository.java
@@ -5,8 +5,10 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.RealMatch.business.domain.entity.CampaignProposal;
 import com.example.RealMatch.business.domain.enums.ProposalStatus;
@@ -59,4 +61,10 @@ public interface CampaignProposalRepository extends JpaRepository<CampaignPropos
             "WHERE p.id IN :ids")
     List<CampaignProposal> findAllByIdWithDetails(@Param("ids") List<Long> ids);
 
+    // User가 연관된 Proposal 모두 삭제 (보낸/받은)
+    // 쿼리 최적화를 위해 @Modifying 어노테이션과 JPQL 사용
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM CampaignProposal cp WHERE cp.senderUserId = :userId OR cp.receiverUserId = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/RealMatch/business/domain/repository/CampaignProposalRepository.java
+++ b/src/main/java/com/example/RealMatch/business/domain/repository/CampaignProposalRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.example.RealMatch.business.domain.entity.CampaignProposal;
 import com.example.RealMatch.business.domain.enums.ProposalStatus;

--- a/src/main/java/com/example/RealMatch/business/domain/repository/CampaignProposalRepository.java
+++ b/src/main/java/com/example/RealMatch/business/domain/repository/CampaignProposalRepository.java
@@ -64,7 +64,6 @@ public interface CampaignProposalRepository extends JpaRepository<CampaignPropos
     // User가 연관된 Proposal 모두 삭제 (보낸/받은)
     // 쿼리 최적화를 위해 @Modifying 어노테이션과 JPQL 사용
     @Modifying
-    @Transactional
     @Query("DELETE FROM CampaignProposal cp WHERE cp.senderUserId = :userId OR cp.receiverUserId = :userId")
     void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/RealMatch/campaign/domain/repository/CampaignLikeRepository.java
+++ b/src/main/java/com/example/RealMatch/campaign/domain/repository/CampaignLikeRepository.java
@@ -42,4 +42,6 @@ public interface CampaignLikeRepository extends JpaRepository<CampaignLike, Long
         group by cl.campaign.id
     """)
     List<Object[]> countByCampaignIdIn(@Param("campaignIds") List<Long> campaignIds);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchBrandHistoryRepository.java
@@ -31,4 +31,6 @@ public interface MatchBrandHistoryRepository extends JpaRepository<MatchBrandHis
     @Modifying
     @Query("UPDATE MatchBrandHistory h SET h.isDeprecated = true WHERE h.user.id = :userId AND h.isDeprecated = false")
     int bulkDeprecateByUserId(@Param("userId") Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/match/domain/repository/MatchCampaignHistoryRepository.java
+++ b/src/main/java/com/example/RealMatch/match/domain/repository/MatchCampaignHistoryRepository.java
@@ -47,4 +47,6 @@ ORDER BY h.id DESC
             Long cursor,
             Pageable pageable
     );
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/user/application/service/UserDeleteService.java
+++ b/src/main/java/com/example/RealMatch/user/application/service/UserDeleteService.java
@@ -1,0 +1,69 @@
+package com.example.RealMatch.user.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.RealMatch.brand.domain.repository.BrandLikeRepository;
+import com.example.RealMatch.brand.domain.repository.BrandRepository;
+import com.example.RealMatch.business.domain.repository.CampaignApplyRepository;
+import com.example.RealMatch.business.domain.repository.CampaignProposalRepository;
+import com.example.RealMatch.campaign.domain.repository.CampaignLikeRepository;
+import com.example.RealMatch.global.exception.CustomException;
+import com.example.RealMatch.match.domain.repository.MatchBrandHistoryRepository;
+import com.example.RealMatch.match.domain.repository.MatchCampaignHistoryRepository;
+import com.example.RealMatch.tag.domain.repository.TagUserRepository;
+import com.example.RealMatch.user.domain.entity.User;
+import com.example.RealMatch.user.domain.repository.AuthenticationMethodRepository;
+import com.example.RealMatch.user.domain.repository.NotificationSettingRepository;
+import com.example.RealMatch.user.domain.repository.UserContentCategoryRepository;
+import com.example.RealMatch.user.domain.repository.UserRepository;
+import com.example.RealMatch.user.domain.repository.UserSignupPurposeRepository;
+import com.example.RealMatch.user.domain.repository.UserTermRepository;
+import com.example.RealMatch.user.presentation.code.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDeleteService {
+
+    private final UserRepository userRepository;
+    private final AuthenticationMethodRepository authenticationMethodRepository;
+    private final BrandRepository brandRepository;
+    private final BrandLikeRepository brandLikeRepository;
+    private final CampaignApplyRepository campaignApplyRepository;
+    private final CampaignLikeRepository campaignLikeRepository;
+    private final CampaignProposalRepository campaignProposalRepository;
+    private final MatchBrandHistoryRepository matchBrandHistoryRepository;
+    private final MatchCampaignHistoryRepository matchCampaignHistoryRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
+    private final TagUserRepository tagUserRepository;
+    private final UserContentCategoryRepository userContentCategoryRepository;
+    private final UserSignupPurposeRepository userSignupPurposeRepository;
+    private final UserTermRepository userTermRepository;
+
+    @Transactional
+    public void deleteUserImmediately(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        deleteRelatedData(userId);
+        userRepository.delete(user);
+    }
+
+    private void deleteRelatedData(Long userId) {
+        tagUserRepository.deleteByUserId(userId);
+        userContentCategoryRepository.deleteByUserId(userId);
+        userSignupPurposeRepository.deleteByUserId(userId);
+        userTermRepository.deleteByUserId(userId);
+        notificationSettingRepository.deleteByUserId(userId);
+        matchBrandHistoryRepository.deleteByUserId(userId);
+        matchCampaignHistoryRepository.deleteByUserId(userId);
+        brandLikeRepository.deleteByUserId(userId);
+        campaignLikeRepository.deleteByUserId(userId);
+        campaignApplyRepository.deleteByUserId(userId);
+        campaignProposalRepository.deleteByUserId(userId);
+        brandRepository.deleteByUserId(userId);
+        authenticationMethodRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/com/example/RealMatch/user/domain/repository/AuthenticationMethodRepository.java
+++ b/src/main/java/com/example/RealMatch/user/domain/repository/AuthenticationMethodRepository.java
@@ -16,5 +16,5 @@ public interface AuthenticationMethodRepository extends JpaRepository<Authentica
 
     boolean existsByProviderAndProviderId(AuthProvider provider, String providerId);
 
-
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/user/domain/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/example/RealMatch/user/domain/repository/NotificationSettingRepository.java
@@ -11,4 +11,5 @@ public interface NotificationSettingRepository extends JpaRepository<Notificatio
     Optional<NotificationSetting> findByUserId(Long userId);
     Optional<NotificationSetting> findOneByUserId(Long userId);
 
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/user/domain/repository/UserContentCategoryRepository.java
+++ b/src/main/java/com/example/RealMatch/user/domain/repository/UserContentCategoryRepository.java
@@ -18,4 +18,6 @@ public interface UserContentCategoryRepository
         where ucc.user.id = :userId
     """)
     List<UserContentCategory> findByUserId(@Param("userId") Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/user/domain/repository/UserTermRepository.java
+++ b/src/main/java/com/example/RealMatch/user/domain/repository/UserTermRepository.java
@@ -17,4 +17,6 @@ public interface UserTermRepository extends JpaRepository<UserTerm, Long> {
     List<UserTerm> findByUserIdAndIsAgreed(Long userId, boolean isAgreed);
 
     Optional<UserTerm> findByUserIdAndTermName(Long userId, TermName termName);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/RealMatch/user/presentation/controller/UserController.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/controller/UserController.java
@@ -15,6 +15,7 @@ import com.example.RealMatch.global.presentation.CustomResponse;
 import com.example.RealMatch.match.domain.entity.enums.BrandSortType;
 import com.example.RealMatch.match.domain.entity.enums.CampaignSortType;
 import com.example.RealMatch.match.presentation.dto.request.MatchRequestDto;
+import com.example.RealMatch.user.application.service.UserDeleteService;
 import com.example.RealMatch.user.application.service.UserFavoriteService;
 import com.example.RealMatch.user.application.service.UserFeatureService;
 import com.example.RealMatch.user.application.service.UserService;
@@ -47,6 +48,7 @@ public class UserController implements UserSwagger {
     private final UserFeatureService userFeatureService;
     private final UserWithdrawService userWithdrawService;
     private final UserFavoriteService  userFavoriteService;
+    private final UserDeleteService userDeleteService;
 
     @Override
     @GetMapping("/me")
@@ -189,5 +191,14 @@ public class UserController implements UserSwagger {
         return CustomResponse.ok(
                 userService.updateSns(userDetails.getUserId(), request)
         );
+    }
+
+    @Override
+    @DeleteMapping("/me/delete-immediately")
+    public CustomResponse<Void> deleteUserImmediately(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userDeleteService.deleteUserImmediately(userDetails.getUserId());
+        return CustomResponse.ok(null);
     }
 }

--- a/src/main/java/com/example/RealMatch/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/example/RealMatch/user/presentation/swagger/UserSwagger.java
@@ -1,6 +1,7 @@
 package com.example.RealMatch.user.presentation.swagger;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -240,5 +241,28 @@ public interface UserSwagger {
     CustomResponse<MyProfileCardResponseDto> updateMySns(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody MyInstagramUpdateRequestDto request
+    );
+
+    @Operation(
+            summary = "회원 즉시 삭제 API By 고경수",
+            description = """
+                로그인한 사용자의 데이터를 즉시 물리 삭제합니다. (복구 불가)
+                
+                삭제 순서:
+                - 유저 관련 자식 데이터 삭제 후
+                - users 물리 삭제
+                
+                주의:
+                - 브랜드 오너/참조 FK가 존재하는 경우 DB 제약조건에 따라 실패할 수 있습니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "즉시 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND"),
+            @ApiResponse(responseCode = "500", description = "연관 데이터 FK 제약으로 삭제 실패 가능")
+    })
+    @DeleteMapping("/me/delete-immediately")
+    CustomResponse<Void> deleteUserImmediately(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }


### PR DESCRIPTION
## Summary
유저 삭제 시 연관된 모든 데이터를 즉시 삭제하는 API를 구현했습니다.


## Changes
- `DELETE /api//me/delete-immediately` 엔드포인트 추가
- 특이사항 : 유저 삭제 시 연관 데이터 cascade 삭제 로직 구현 
  - CampaignProposal (sender/receiver 모두)
  - 기타 유저 연관 엔티티
- `CampaignProposalRepository.deleteByUserId()` 메서드 관련
  - `@Query` 사용하여 senderUserId, receiverUserId 모두 처리
- 유저 삭제 서비스 로직 구현


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
Closes #365 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->