### PR TITLE
fix(#392): 브랜드 상세 조회 API에서 브랜드의 유저의 ID가 나올 수 있도록 변경

### DIFF
--- a/src/main/java/com/example/RealMatch/brand/application/service/BrandService.java
+++ b/src/main/java/com/example/RealMatch/brand/application/service/BrandService.java
@@ -106,6 +106,7 @@ public class BrandService {
         BrandDetailResponseDto.BrandDetailResponseDtoBuilder responseBuilder = BrandDetailResponseDto.builder()
                 .userId(currentUserId)
                 .brandName(brand.getBrandName())
+                .brandUserId(String.valueOf(brand.getUser().getId()))
                 .brandImages(brandImages)
                 .logoUrl(brand.getLogoUrl())
                 .simpleIntro(brand.getSimpleIntro())

--- a/src/main/java/com/example/RealMatch/brand/presentation/dto/response/BrandDetailResponseDto.java
+++ b/src/main/java/com/example/RealMatch/brand/presentation/dto/response/BrandDetailResponseDto.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class BrandDetailResponseDto {
     private Long userId;
     private String brandName;
+    private String brandUserId;
     private List<String> brandImages;
     private String logoUrl;
     private String simpleIntro;


### PR DESCRIPTION
## Summary
브랜드 상세 조회 API에서 브랜드의 유저의 ID가 나올 수 있도록 변경

## Changes
- 브랜드 상세 조회 API: 브랜드의 유저의 ID 출력하도록 Dto 와 서비스 로직 수정


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [X] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
#392 
