### PR TITLE
fix(#396): 캠페인 제안 상세 조회에 제품 이름 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/brand/domain/repository/BrandAvailableSponsorRepository.java
+++ b/src/main/java/com/example/RealMatch/brand/domain/repository/BrandAvailableSponsorRepository.java
@@ -16,6 +16,5 @@ public interface BrandAvailableSponsorRepository extends JpaRepository<BrandAvai
     @Query("SELECT s FROM BrandAvailableSponsor s LEFT JOIN FETCH s.images WHERE s.brand.id = :brandId")
     List<BrandAvailableSponsor> findByBrandIdWithImages(@Param("brandId") Long brandId);
 
-    Optional<BrandAvailableSponsor>
-    findByBrandIdAndId(Long brandId, Long id);
+    Optional<BrandAvailableSponsor> findByBrandIdAndId(Long brandId, Long id);
 }

--- a/src/main/java/com/example/RealMatch/brand/domain/repository/BrandAvailableSponsorRepository.java
+++ b/src/main/java/com/example/RealMatch/brand/domain/repository/BrandAvailableSponsorRepository.java
@@ -1,6 +1,7 @@
 package com.example.RealMatch.brand.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +15,7 @@ public interface BrandAvailableSponsorRepository extends JpaRepository<BrandAvai
 
     @Query("SELECT s FROM BrandAvailableSponsor s LEFT JOIN FETCH s.images WHERE s.brand.id = :brandId")
     List<BrandAvailableSponsor> findByBrandIdWithImages(@Param("brandId") Long brandId);
+
+    Optional<BrandAvailableSponsor>
+    findByBrandIdAndId(Long brandId, Long id);
 }

--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalQueryService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalQueryService.java
@@ -3,6 +3,8 @@ package com.example.RealMatch.business.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.RealMatch.brand.domain.entity.BrandAvailableSponsor;
+import com.example.RealMatch.brand.domain.repository.BrandAvailableSponsorRepository;
 import com.example.RealMatch.business.domain.entity.CampaignProposal;
 import com.example.RealMatch.business.domain.repository.CampaignProposalRepository;
 import com.example.RealMatch.business.exception.BusinessErrorCode;
@@ -17,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class CampaignProposalQueryService {
 
     private final CampaignProposalRepository campaignProposalRepository;
+    private final BrandAvailableSponsorRepository brandAvailableSponsorRepository;
 
     public CampaignProposalDetailResponse getProposalDetail(
             Long userId,
@@ -25,6 +28,19 @@ public class CampaignProposalQueryService {
         CampaignProposal proposal = campaignProposalRepository.findByIdWithTags(proposalId)
                 .orElseThrow(() -> new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_NOT_FOUND));
 
-        return CampaignProposalDetailResponse.from(proposal);
+        String productName = null;
+
+        // TODO: 데모데이 이후에 해당 제품이 없으면 에러 던지는 방향으로 수정 필요!! + 조회 권한 로직 추가 필요(본인만 조회 가능)
+        if (proposal.getProductId() != null) {
+            productName = brandAvailableSponsorRepository
+                    .findByBrandIdAndId(
+                            proposal.getBrand().getId(),
+                            proposal.getProductId()
+                    )
+                    .map(BrandAvailableSponsor::getName)
+                    .orElse(null);
+        }
+
+        return CampaignProposalDetailResponse.from(proposal, productName);
     }
 }

--- a/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalQueryService.java
+++ b/src/main/java/com/example/RealMatch/business/application/service/CampaignProposalQueryService.java
@@ -1,5 +1,7 @@
 package com.example.RealMatch.business.application.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,19 +29,13 @@ public class CampaignProposalQueryService {
     ) {
         CampaignProposal proposal = campaignProposalRepository.findByIdWithTags(proposalId)
                 .orElseThrow(() -> new CustomException(BusinessErrorCode.CAMPAIGN_PROPOSAL_NOT_FOUND));
-
-        String productName = null;
-
+        
         // TODO: 데모데이 이후에 해당 제품이 없으면 에러 던지는 방향으로 수정 필요!! + 조회 권한 로직 추가 필요(본인만 조회 가능)
-        if (proposal.getProductId() != null) {
-            productName = brandAvailableSponsorRepository
-                    .findByBrandIdAndId(
-                            proposal.getBrand().getId(),
-                            proposal.getProductId()
-                    )
-                    .map(BrandAvailableSponsor::getName)
-                    .orElse(null);
-        }
+        String productName = Optional.ofNullable(proposal.getProductId())
+                .flatMap(productId -> brandAvailableSponsorRepository
+                        .findByBrandIdAndId(proposal.getBrand().getId(), productId))
+                .map(BrandAvailableSponsor::getName)
+                .orElse(null);
 
         return CampaignProposalDetailResponse.from(proposal, productName);
     }

--- a/src/main/java/com/example/RealMatch/business/presentation/dto/response/CampaignProposalDetailResponse.java
+++ b/src/main/java/com/example/RealMatch/business/presentation/dto/response/CampaignProposalDetailResponse.java
@@ -25,6 +25,7 @@ public class CampaignProposalDetailResponse {
 
     private Long rewardAmount;
     private Long productId;
+    private String productName;
 
     private LocalDate startDate;
     private LocalDate endDate;
@@ -36,7 +37,7 @@ public class CampaignProposalDetailResponse {
 
     private CampaignContentTagResponse contentTags;
 
-    public static CampaignProposalDetailResponse from(CampaignProposal proposal) {
+    public static CampaignProposalDetailResponse from(CampaignProposal proposal, String productName) {
         Campaign campaign = proposal.getCampaign();
 
         return CampaignProposalDetailResponse.builder()
@@ -49,6 +50,7 @@ public class CampaignProposalDetailResponse {
                 .description(proposal.getCampaignDescription())
                 .rewardAmount(Long.valueOf(proposal.getRewardAmount()))
                 .productId(proposal.getProductId())
+                .productName(productName)
                 .startDate(proposal.getStartDate())
                 .endDate(proposal.getEndDate())
                 .status(proposal.getStatus().name())


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->
fix(#396): 캠페인 제안 상세 조회에 제품 이름 추가

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
캠페인 제안 상세조회에서 제품 이름 추가

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- [x] productName을 응답에 추가함 
<img width="884" height="436" alt="image" src="https://github.com/user-attachments/assets/3843b1c3-7900-42f3-8514-f634d87b6045" />


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
#118 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
브랜드와 제품이 제대로 매칭되어야만 조회가 가능합니다. 만약 브랜드와 제품이 제대로 매칭되지않은  더미 데이터의 경우 productName이 null이 반환됩니다. (데모데이 이후 에러 반환하는 것으로 수정 필요) 
또한 데모데이 이후 본인이 보낸 캠페인 제안만 조회 가능하도록 권한 확인 로직도 추가예정입니다. 