### PR TITLE
[REFACTOR] 알림 조회 redis 캐싱 추가

### DIFF
--- a/src/main/java/com/example/RealMatch/notification/application/service/NotificationQueryService.java
+++ b/src/main/java/com/example/RealMatch/notification/application/service/NotificationQueryService.java
@@ -18,6 +18,7 @@ import com.example.RealMatch.notification.domain.entity.enums.NotificationCatego
 import com.example.RealMatch.notification.domain.entity.enums.NotificationKind;
 import com.example.RealMatch.notification.domain.repository.NotificationRepository;
 import com.example.RealMatch.notification.exception.NotificationErrorCode;
+import com.example.RealMatch.notification.infrastructure.redis.NotificationUnreadCountCache;
 import com.example.RealMatch.notification.presentation.dto.response.NotificationDateGroup;
 import com.example.RealMatch.notification.presentation.dto.response.NotificationListResponse;
 import com.example.RealMatch.notification.presentation.dto.response.NotificationResponse;
@@ -30,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class NotificationQueryService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationUnreadCountCache unreadCountCache;
 
     private static final DateTimeFormatter DATE_LABEL_FORMATTER =
             DateTimeFormatter.ofPattern("yy.MM.dd (E)", Locale.KOREAN);
@@ -52,7 +54,7 @@ public class NotificationQueryService {
 
         List<NotificationDateGroup> groups = buildDateGroups(notificationPage.getContent());
 
-        long unreadCount = notificationRepository.countUnreadByUserId(userId);
+        long unreadCount = getUnreadCount(userId);
 
         return new NotificationListResponse(
                 items,
@@ -66,7 +68,12 @@ public class NotificationQueryService {
     }
 
     public long getUnreadCount(Long userId) {
-        return notificationRepository.countUnreadByUserId(userId);
+        return unreadCountCache.get(userId)
+                .orElseGet(() -> {
+                    long count = notificationRepository.countUnreadByUserId(userId);
+                    unreadCountCache.set(userId, count);
+                    return count;
+                });
     }
 
     private List<NotificationKind> resolveKinds(String filter) {

--- a/src/main/java/com/example/RealMatch/notification/application/service/NotificationService.java
+++ b/src/main/java/com/example/RealMatch/notification/application/service/NotificationService.java
@@ -22,6 +22,7 @@ import com.example.RealMatch.notification.domain.repository.NotificationDelivery
 import com.example.RealMatch.notification.domain.repository.NotificationOutboxRepository;
 import com.example.RealMatch.notification.domain.repository.NotificationRepository;
 import com.example.RealMatch.notification.exception.NotificationErrorCode;
+import com.example.RealMatch.notification.infrastructure.redis.NotificationUnreadCountCache;
 import com.example.RealMatch.user.domain.entity.enums.NotificationChannel;
 
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,7 @@ public class NotificationService {
     private final NotificationDeliveryRepository notificationDeliveryRepository;
     private final NotificationOutboxRepository notificationOutboxRepository;
     private final NotificationChannelResolver channelResolver;
+    private final NotificationUnreadCountCache unreadCountCache;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Notification create(CreateNotificationCommand command) {
@@ -57,6 +59,8 @@ public class NotificationService {
                 .build();
 
         Notification savedNotification = notificationRepository.save(notification);
+
+        unreadCountCache.invalidate(command.getUserId());
 
         createPendingDeliveriesWithOutbox(
                 savedNotification.getId(),
@@ -112,15 +116,19 @@ public class NotificationService {
     public void markAsRead(Long userId, UUID notificationId) {
         Notification notification = findNotificationForUser(userId, notificationId);
         notification.markAsRead();
+        unreadCountCache.invalidate(userId);
     }
 
     public int markAllAsRead(Long userId) {
-        return notificationRepository.markAllAsRead(userId);
+        int count = notificationRepository.markAllAsRead(userId);
+        unreadCountCache.invalidate(userId);
+        return count;
     }
 
     public void softDelete(Long userId, UUID notificationId) {
         Notification notification = findNotificationForUser(userId, notificationId);
         notification.softDelete();
+        unreadCountCache.invalidate(userId);
     }
 
     private Notification findNotificationForUser(Long userId, UUID notificationId) {

--- a/src/main/java/com/example/RealMatch/notification/application/service/NotificationService.java
+++ b/src/main/java/com/example/RealMatch/notification/application/service/NotificationService.java
@@ -60,13 +60,13 @@ public class NotificationService {
 
         Notification savedNotification = notificationRepository.save(notification);
 
-        unreadCountCache.invalidate(command.getUserId());
-
         createPendingDeliveriesWithOutbox(
                 savedNotification.getId(),
                 command.getKind(),
                 command.getEventId(),
                 command.getUserId());
+
+        unreadCountCache.invalidateAfterCommit(command.getUserId());
 
         return savedNotification;
     }
@@ -116,19 +116,19 @@ public class NotificationService {
     public void markAsRead(Long userId, UUID notificationId) {
         Notification notification = findNotificationForUser(userId, notificationId);
         notification.markAsRead();
-        unreadCountCache.invalidate(userId);
+        unreadCountCache.invalidateAfterCommit(userId);
     }
 
     public int markAllAsRead(Long userId) {
         int count = notificationRepository.markAllAsRead(userId);
-        unreadCountCache.invalidate(userId);
+        unreadCountCache.invalidateAfterCommit(userId);
         return count;
     }
 
     public void softDelete(Long userId, UUID notificationId) {
         Notification notification = findNotificationForUser(userId, notificationId);
         notification.softDelete();
-        unreadCountCache.invalidate(userId);
+        unreadCountCache.invalidateAfterCommit(userId);
     }
 
     private Notification findNotificationForUser(Long userId, UUID notificationId) {

--- a/src/main/java/com/example/RealMatch/notification/infrastructure/redis/NotificationUnreadCountCache.java
+++ b/src/main/java/com/example/RealMatch/notification/infrastructure/redis/NotificationUnreadCountCache.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import lombok.RequiredArgsConstructor;
 
@@ -65,6 +67,29 @@ public class NotificationUnreadCountCache {
             redisTemplate.delete(KEY_PREFIX + userId);
         } catch (Exception e) {
             LOG.warn("[UnreadCountCache] Redis invalidate failed. userId={}", userId, e);
+        }
+    }
+
+    /**
+     * 트랜잭션 커밋 완료 후 캐시를 무효화합니다.
+     * <p>커밋 이전 무효화 시 다른 스레드가 아직 커밋되지 않은 DB 값을 읽어
+     * 캐시에 저장하는 레이스 컨디션을 방지합니다.
+     */
+    public void invalidateAfterCommit(Long userId) {
+        if (userId == null) {
+            return;
+        }
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            invalidate(userId);
+                        }
+                    }
+            );
+        } else {
+            invalidate(userId);
         }
     }
 }

--- a/src/main/java/com/example/RealMatch/notification/infrastructure/redis/NotificationUnreadCountCache.java
+++ b/src/main/java/com/example/RealMatch/notification/infrastructure/redis/NotificationUnreadCountCache.java
@@ -1,0 +1,70 @@
+package com.example.RealMatch.notification.infrastructure.redis;
+
+import java.time.Duration;
+import java.util.OptionalLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 미읽음 알림 개수 조회 성능 최적화를 위한 Redis 캐시.
+ * <p>캐시 키: notification:unread:{userId}
+ * <p>캐시 무효화: 알림 생성, 읽음 처리, 전체 읽기, 소프트 삭제 시 호출
+ * <p>Redis 장애 시 DB 조회로 폴백
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificationUnreadCountCache {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationUnreadCountCache.class);
+    private static final String KEY_PREFIX = "notification:unread:";
+    private static final Duration TTL = Duration.ofMinutes(10);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public OptionalLong get(Long userId) {
+        if (userId == null) {
+            return OptionalLong.empty();
+        }
+        try {
+            String key = KEY_PREFIX + userId;
+            String value = redisTemplate.opsForValue().get(key);
+            if (value == null) {
+                return OptionalLong.empty();
+            }
+            return OptionalLong.of(Long.parseLong(value));
+        } catch (NumberFormatException e) {
+            invalidate(userId);
+            return OptionalLong.empty();
+        } catch (Exception e) {
+            LOG.warn("[UnreadCountCache] Redis get failed, fallback to DB. userId={}", userId, e);
+            return OptionalLong.empty();
+        }
+    }
+
+    public void set(Long userId, long count) {
+        if (userId == null) {
+            return;
+        }
+        try {
+            redisTemplate.opsForValue().set(KEY_PREFIX + userId, String.valueOf(count), TTL);
+        } catch (Exception e) {
+            LOG.warn("[UnreadCountCache] Redis set failed. userId={}", userId, e);
+        }
+    }
+
+    public void invalidate(Long userId) {
+        if (userId == null) {
+            return;
+        }
+        try {
+            redisTemplate.delete(KEY_PREFIX + userId);
+        } catch (Exception e) {
+            LOG.warn("[UnreadCountCache] Redis invalidate failed. userId={}", userId, e);
+        }
+    }
+}


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
미읽음 알림 개수 조회 API(GET /api/v1/notifications/unread-count) 성능 개선을 위해 Redis 캐시를 적용했습니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->

- NotificationUnreadCountCache 컴포넌트 추가 (캐시 키: notification:unread:{userId}, TTL: 10분)
- NotificationQueryService.getUnreadCount(): 캐시 조회 → 미스 시 DB 조회 후 캐시 저장
- NotificationQueryService.getNotifications(): unread count를 getUnreadCount()로 조회해 캐시 재사용
- NotificationService: 알림 생성, 읽음 처리, 전체 읽기, 소프트 삭제 시 캐시 무효화
- Redis 장애 시 DB 조회로 폴백 (예외 처리 추가)

## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #403 

## 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->